### PR TITLE
Replace index page with redesigned layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1422 +1,1434 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>筋トレ記録アプリ | BUILD_TAG=FULL-20250928-IPHONE-FIX-POS-KBSAFE-TIMED-BACKUP+WORKOUTROUTE</title>
-<meta name="color-scheme" content="light">
-<script src="https://cdn.tailwindcss.com"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
-<style>
-  :root { --nav-h: 64px; --kb: 0px; }
-  input, select, textarea, button { font-size: 16px; }
-  main { padding-bottom: calc(var(--nav-h) + 24px + env(safe-area-inset-bottom) + var(--kb)); }
-  nav { padding-bottom: calc(env(safe-area-inset-bottom)); transition: transform .2s ease, opacity .2s ease; }
-  body.kb-open nav { transform: translateY(100%); opacity: 0; pointer-events: none; }
-  .shadow-soft { box-shadow: 0 10px 25px rgba(0,0,0,.08); }
-  .modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,.35); backdrop-filter: blur(2px); }
-  .modal-card { max-width: 680px; }
-  .truncate-2 { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
-  .min-w-0 { min-width: 0; }
-  .wrap-pad { padding-left: 12px; padding-right: 12px; }
-  .narrow-date { max-width: 240px; }
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <title>筋トレ記録アプリ</title>
+  <meta name="color-scheme" content="light dark">
+  <!-- Tailwind の safelist 設定 -->
+  <script>
+    window.tailwind = {
+      config: {
+        darkMode: 'media',
+        safelist: [
+          { pattern: /(grid|flex|items-center|justify-between|justify-center|space-y-\d+)/ },
+          { pattern: /(grid-cols-\d+|md:grid-cols-\d+)/ },
+          { pattern: /(col-span-\d+)/ },
+          { pattern: /(p-\d+|px-\d+|py-\d+|m-\d+)/ },
+          { pattern: /(rounded(-[a-z]+)?|border(-[a-z]+)?)/ },
+          { pattern: /(bg-[a-z0-9-\/]+|text-[a-z0-9-\/]+|border-[a-z0-9-\/]+)/ }
+        ]
+      }
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+  <style>
+    :root {
+      --nav-h: 64px;
+      --kb: 0px;
+      --accent:#4f46e5;
+      --bg:#ffffff;
+      --fg:#0f172a;
+      --card:#f8fafc;
+      --muted:#64748b;
+      --border:#e2e8f0;
+    }
+    [data-theme="dark"] {
+      --bg:#0b1220;
+      --fg:#e5e7eb;
+      --card:#111827;
+      --muted:#9ca3af;
+      --border:#1f2937;
+    }
+    html,body { height:100% }
+    body { background:var(--bg); color:var(--fg) }
+    input,select,textarea,button{font-size:16px}
+    main{padding-bottom:calc(var(--nav-h) + 24px + env(safe-area-inset-bottom) + var(--kb))}
+    nav{padding-bottom:calc(env(safe-area-inset-bottom));transition:transform .2s,opacity .2s}
+    body.kb-open nav{transform:translateY(100%);opacity:0;pointer-events:none}
+    .shadow-soft{box-shadow:0 10px 25px rgba(0,0,0,.08)}
+    .modal-bg{position:fixed;inset:0;background:rgba(0,0,0,.35);backdrop-filter:blur(2px)}
+    .modal-card{max-width:680px}
+    .card{background:var(--card);border:1px solid var(--border);border-radius:1rem;padding:1rem}
+  </style>
 </head>
-<body class="bg-gray-50 text-gray-900">
-  <div id="error-bar" class="fixed top-0 left-0 right-0 z-50 hidden">
-    <div class="bg-red-600 text-white px-4 py-2 text-sm flex items-start gap-3">
-      <span class="font-semibold">Script error</span>
-      <span id="error-text" class="flex-1"></span>
-      <button id="error-close" class="underline">閉じる</button>
-    </div>
-  </div>
-
-  <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b border-gray-200">
-    <div class="max-w-3xl mx-auto wrap-pad px-4 py-3 flex items-center justify-between">
-      <h1 class="text-lg font-bold">筋トレ記録</h1>
-      <div class="text-xs text-gray-500">PWA / Local-only</div>
-    </div>
-  </header>
-
-  <main id="app" class="max-w-3xl mx-auto wrap-pad px-4 py-4 space-y-4">
-        <section id="view-home" class="hidden">
-      <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-2">
-        <div>
-          <label class="text-xs text-gray-500 block">日付</label>
-          <input id="inp-date" type="date" class="w-full narrow-date border rounded-lg px-3 py-2">
-        </div>
-      </div>
-
-  <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-3">
-    <div>
-      <label class="text-xs text-gray-500 block mb-1">部位（新規ブロックの初期値）</label>
-      <div class="grid grid-cols-3 gap-2">
-        <button class="part-btn px-3 py-2 rounded-xl bg-white border shadow-soft" data-part="胸">胸</button>
-        <button class="part-btn px-3 py-2 rounded-xl bg-white border shadow-soft" data-part="背中">背中</button>
-        <button class="part-btn px-3 py-2 rounded-xl bg-white border shadow-soft" data-part="肩">肩</button>
-        <button class="part-btn px-3 py-2 rounded-xl bg-white border shadow-soft" data-part="腕">腕</button>
-        <button class="part-btn px-3 py-2 rounded-xl bg-white border shadow-soft" data-part="脚">脚</button>
-        <button class="part-btn px-3 py-2 rounded-xl bg-white border shadow-soft" data-part="腹筋">腹筋</button>
-      </div>
-    </div>
-    <div class="grid grid-cols-2 gap-3">
-      <div class="rounded-xl border bg-white p-3">
-        <div class="text-xs text-gray-500">直近1週間のトレ日数</div>
-        <div id="stat-week" class="text-2xl font-bold">0</div>
-      </div>
-      <div class="rounded-xl border bg-white p-3">
-        <div class="text-xs text-gray-500">直近1ヶ月のトレ日数</div>
-        <div id="stat-month" class="text-2xl font-bold">0</div>
-      </div>
-    </div>
-    <div class="pt-1">
-      <button id="btn-start-or-resume" class="w-full px-4 py-3 rounded-xl bg-gray-900 text-white text-sm">
-        今日のトレーニングを開始
-      </button>
-    </div>
-  </div>
-</section>
-
-<section id="view-workout" class="hidden">
-  <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-3">
-    <div class="flex items-center justify-between">
-      <div class="text-sm">
-        <div class="text-[11px] text-gray-500">日付</div>
-        <div id="workout-date" class="font-semibold">-</div>
-      </div>
-      <div class="text-sm">
-        <div class="text-[11px] text-gray-500">部位</div>
-        <div id="workout-part" class="font-semibold">-</div>
-      </div>
-      <div class="flex gap-2">
-        <button id="btn-back-to-home" class="px-3 py-2 rounded-xl border text-sm">戻る</button>
-        <button id="btn-save-workout" class="px-3 py-2 rounded-xl bg-gray-900 text-white text-sm">保存</button>
-      </div>
-    </div>
-    <div class="flex items-center justify-between">
-      <div class="text-sm text-gray-600">ブロック</div>
-      <div class="flex gap-2">
-        <button id="btn-add-block" class="px-3 py-2 rounded-xl border text-sm bg-white">ブロック追加</button>
-      </div>
-    </div>
-  </div>
-  <div id="blocks" class="space-y-4"></div>
-</section>
-
-<section id="view-history" class="hidden">
-  <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-3">
-    <div class="grid grid-cols-2 gap-2">
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500 block">開始日</label>
-        <input id="filter-start" type="date" class="w-full narrow-date border rounded-lg px-3 py-2">
-      </div>
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500 block">終了日</label>
-        <input id="filter-end" type="date" class="w-full narrow-date border rounded-lg px-3 py-2">
-      </div>
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500">部位</label>
-        <select id="filter-part" class="w-full border rounded-lg px-3 py-2"></select>
-      </div>
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500">種目名</label>
-        <select id="filter-ex" class="w-full border rounded-lg px-3 py-2"></select>
-      </div>
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500">器具</label>
-        <select id="filter-eq" class="w-full border rounded-lg px-3 py-2"></select>
-      </div>
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500">アタッチメント</label>
-        <select id="filter-att" class="w-full border rounded-lg px-3 py-2"></select>
-      </div>
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500">角度</label>
-        <select id="filter-ang" class="w-full border rounded-lg px-3 py-2"></select>
-      </div>
-      <div class="min-w-0">
-        <label class="text-xs text-gray-500">ポジション</label>
-        <select id="filter-pos" class="w-full border rounded-lg px-3 py-2"></select>
-      </div>
-    </div>
-    <div class="flex gap-2">
-      <button id="btn-apply-filter" class="px-3 py-2 rounded-xl bg-gray-900 text-white">絞り込み</button>
-      <button id="btn-clear-filter" class="px-3 py-2 rounded-xl bg-white border">クリア</button>
-    </div>
-  </div>
-
-  <div id="history-chart-wrap" class="rounded-2xl border bg-white p-3 shadow-soft mt-3 hidden">
-    <div class="flex items-center justify-between mb-2">
-      <div class="text-sm text-gray-600">1RM推移</div>
-      <button id="btn-back-to-home-from-simple" class="px-3 py-1.5 rounded-lg border hidden">入力画面に戻る</button>
-    </div>
-    <canvas id="history-chart" height="160"></canvas>
-  </div>
-
-  <div id="history-list" class="mt-3 space-y-3"></div>
-</section>
-
-<section id="view-settings" class="hidden">
-  <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-4">
-    <div>
-      <div class="text-sm font-semibold mb-1">リスト編集</div>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <div>
-          <label class="text-xs text-gray-500">部位（1行1項目）</label>
-          <textarea id="list-parts" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
-        </div>
-        <div>
-          <label class="text-xs text-gray-500">器具（1行1項目）</label>
-          <textarea id="list-equip" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
-        </div>
-        <div>
-          <label class="text-xs text-gray-500">アタッチメント（1行1項目／先頭は「なし」を推奨）</label>
-          <textarea id="list-attach" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
-        </div>
-        <div>
-          <label class="text-xs text-gray-500">角度（1行1項目）</label>
-          <textarea id="list-angle" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
-        </div>
-        <div>
-          <label class="text-xs text-gray-500">ポジション（1行1項目）</label>
-          <textarea id="list-position" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
-        </div>
-      </div>
-    </div>
-
-    <div class="border-t pt-3">
-      <div class="text-sm font-semibold mb-1">種目マスタ（部位別管理）</div>
-      <p class="text-xs text-gray-500 mb-2">※ 種目名は器具名や角度名を含めない形式。表示は常にあいうえお順。削除は確認ポップアップあり。</p>
-      <div id="part-boxes" class="space-y-3"></div>
-      <div class="flex gap-2 mt-2">
-        <button id="btn-save-lists" class="px-3 py-2 rounded-xl bg-gray-900 text-white">保存</button>
-        <button id="btn-reset-defaults" class="px-3 py-2 rounded-xl bg-white border">デフォルト復元</button>
-      </div>
-    </div>
-
-    <div class="border-t pt-3">
-      <div class="text-sm font-semibold mb-1">バックアップ</div>
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <label class="text-sm">自動バックアップ</label>
-          <input id="bk-auto" type="checkbox" class="w-5 h-5">
-        </div>
-        <div class="grid grid-cols-2 gap-2">
-          <div>
-            <label class="text-xs text-gray-500">頻度（分）</label>
-            <input id="bk-frequency" type="number" min="5" class="w-full border rounded px-2 py-1" />
-          </div>
-          <div class="text-xs text-gray-500 flex items-end">最終: <span id="bk-last" class="ml-1">-</span></div>
-        </div>
-        <div class="flex flex-wrap gap-2">
-          <button id="bk-choose" class="px-3 py-2 rounded-xl border">保存先を選ぶ</button>
-          <button id="bk-now" class="px-3 py-2 rounded-xl border">今すぐバックアップ</button>
-          <button id="bk-restore" class="px-3 py-2 rounded-xl border">バックアップから復元</button>
-        </div>
-        <div class="text-xs text-gray-500">iPhoneでは「今すぐバックアップ」→共有→Files（iCloud Drive）に保存で同期可能。</div>
-      </div>
-    </div>
-
-    <div class="border-t pt-3">
-      <div class="text-sm font-semibold mb-1">データ管理</div>
-      <div class="flex flex-wrap gap-2">
-        <button id="btn-export-csv" class="px-3 py-2 rounded-xl bg-white border">CSVエクスポート</button>
-        <label class="px-3 py-2 rounded-xl bg-white border cursor-pointer">
-          CSVインポート
-          <input id="input-import-csv" type="file" accept=".csv,text/csv" class="hidden">
-        </label>
-        <button id="btn-clear-data" class="px-3 py-2 rounded-xl bg-red-50 text-red-700 border border-red-200">全データ削除</button>
-      </div>
-      <p class="text-xs text-gray-500 mt-2">CSV列: date,part,exercise,equipment,attachment,angle,position,setIndex,warmup,weight,repsSelf,repsAssist,durationSec,note,oneRM</p>
-    </div>
-  </div>
-</section>
-
-  </main>
-
-  <nav class="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur border-t border-gray-200" style="height: var(--nav-h);">
-    <div class="max-w-3xl mx-auto wrap-pad px-6 h-full">
-      <div class="grid grid-cols-3 h-full">
-        <button data-route="#/home" class="tab-btn flex flex-col items-center justify-center gap-0.5">
-          <span class="text-base">🏠</span>
-          <span class="text-xs">ホーム</span>
-        </button>
-        <button data-route="#/history" class="tab-btn flex flex-col items-center justify-center gap-0.5">
-          <span class="text-base">🗂️</span>
-          <span class="text-xs">履歴</span>
-        </button>
-        <button data-route="#/settings" class="tab-btn flex flex-col items-center justify-center gap-0.5">
-          <span class="text-base">⚙️</span>
-          <span class="text-xs">設定</span>
-        </button>
-      </div>
-    </div>
-  </nav>
-
-    <template id="tpl-block">
-    <div class="block-card rounded-2xl border bg-white p-3 shadow-soft space-y-3">
-      <div class="flex items-center justify-between gap-2">
-        <div class="flex items-center gap-2 min-w-0">
-          <span class="text-xs text-gray-500">ブロック</span>
-          <span class="block-index text-sm font-semibold">#1</span>
-          <span class="text-[11px] text-gray-500 block-part"></span>
-        </div>
-        <div class="flex gap-2">
-          <button class="btn-choose-ex px-2 py-1.5 rounded-lg border text-sm">種目選択/追加</button>
-          <button class="btn-del-block px-2 py-1.5 rounded-lg border border-red-200 text-red-700 text-sm">ブロック削除</button>
-        </div>
-      </div>
-      <div class="ex-config space-y-3"></div>
-      <div class="set-area space-y-2">
-        <div class="flex items-center justify-between">
-          <div class="text-sm text-gray-600">セット</div>
-          <div class="flex gap-2">
-            <button class="btn-add-set px-2 py-1.5 rounded-md bg-white border text-sm">セット追加</button>
-            <button class="btn-clear-sets px-2 py-1.5 rounded-md border text-sm">全セット削除</button>
-          </div>
-        </div>
-        <div class="set-list space-y-2"></div>
-      </div>
-    </div>
-  </template>
-
-  <template id="tpl-ex-config-row">
-    <div class="ex-config-row space-y-1">
-      <div class="text-sm font-semibold ex-name">種目名</div>
-      <div class="grid grid-cols-4 gap-1">
-        <select class="ex-eq col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
-        <select class="ex-att col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
-        <select class="ex-ang col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
-        <select class="ex-pos col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
-      </div>
-      <div class="text-[11px] text-gray-500 ex-meta">最高重量: - / 最高1RM: - / 前回: -</div>
-    </div>
-  </template>
-
-  <template id="tpl-set-card">
-    <div class="set-card rounded-xl border p-2 bg-gray-50 space-y-2">
-      <div class="flex items-center justify-between">
-        <div class="text-sm font-semibold">Set <span class="set-no">#1</span></div>
-        <div class="flex items-center gap-2">
-          <label class="inline-flex items-center gap-1 text-xs"><input type="checkbox" class="set-warm border rounded"> W-Up</label>
-          <button class="btn-dup-set px-2 py-1.5 rounded-md border text-xs">複製</button>
-          <button class="btn-del-set px-2 py-1.5 rounded-md border text-xs">削除</button>
-        </div>
-      </div>
-      <div class="ex-items space-y-2"></div>
-    </div>
-  </template>
-
-  <template id="tpl-ex-item-row">
-    <div class="ex-item space-y-1">
-      <div class="text-xs ex-title font-medium">種目1</div>
-      <div class="grid grid-cols-12 gap-1 items-center">
-        <input type="number" inputmode="decimal" placeholder="重量" class="ex-weight col-span-4 border rounded px-2 py-1" />
-        <input type="number" inputmode="numeric" placeholder="自力" class="ex-reps col-span-2 border rounded px-2 py-1" />
-        <input type="number" inputmode="numeric" placeholder="補助" class="ex-assist col-span-2 border rounded px-2 py-1" />
-        <div class="col-span-4 flex items-center gap-1">
-          <input type="number" inputmode="numeric" placeholder="時間(秒)" class="ex-sec flex-1 border rounded px-2 py-1" />
-          <button class="ex-sec-toggle px-2 py-1 rounded border text-xs">▶</button>
-        </div>
-        <input type="text" placeholder="メモ" class="ex-note col-span-12 border rounded px-2 py-1" />
-        <div class="col-span-12 text-[11px] text-gray-500">推定1RM: <span class="ex-1rm">-</span> kg</div>
-      </div>
-    </div>
-  </template>
-
-  <script>
-    (()=> {
-      const bar = document.getElementById('error-bar');
-      const text = document.getElementById('error-text');
-      const close = document.getElementById('error-close');
-      function show(msg){ text.textContent = String(msg||'Unknown error'); bar.classList.remove('hidden'); }
-      window.addEventListener('error', e=> show(e.message));
-      window.addEventListener('unhandledrejection', e=> show((e.reason&&e.reason.message)||e.reason));
-      close.addEventListener('click', ()=> bar.classList.add('hidden'));
-      window.__forceError = ()=> { throw new Error('Forced error'); };
-    })();
-
-    const $ = (sel, root=document)=> root.querySelector(sel);
-    const $$ = (sel, root=document)=> Array.from(root.querySelectorAll(sel));
-    const debounce = (fn, ms=300)=> { let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a), ms); }; };
-    const todayISO = ()=> new Date().toISOString().slice(0,10);
-    const toCSV = rows => rows.map(r=> r.map(v=>{
-      const s = v==null?'':String(v); return /[",\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s;
-    }).join(',')).join('\n');
-    const escapeHtml = s => String(s).replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
-    const sortJa = (arr)=> arr.slice().sort((a,b)=> String(a).localeCompare(String(b),'ja',{usage:'sort',sensitivity:'base'}));
-    const sortExerciseMapJa = (map)=> map.slice().sort((a,b)=> (a.name||'').localeCompare(b.name||'','ja',{usage:'sort',sensitivity:'base'}));
-
-    // === PATCH: routes & helpers ===
-    const ROUTES = Object.freeze({
-      HOME: '#/home',
-      WORKOUT: '#/workout',
-      HISTORY: '#/history',
-      SETTINGS: '#/settings',
-    });
-    const VIEWS = Object.freeze({
-      HOME: '#view-home',
-      WORKOUT: '#view-workout',
-      HISTORY: '#view-history',
-      SETTINGS: '#view-settings',
-    });
-
-    function orderWithNoneFirst(arr){
-      const a = Array.from(new Set(arr||[]));
-      const head = a.filter(v => v === 'なし');
-      const rest = a.filter(v => v !== 'なし')
-                    .sort((x,y)=> x.localeCompare(y,'ja',{usage:'sort',sensitivity:'base'}));
-      return [...head, ...rest];
-    }
-
-    const SCHEMA_VERSION = 8;
-    const NS = 'workout-app';
-    const K_LISTS     = NS+':lists';
-    const K_WORKOUTS  = NS+':workouts';
-    const K_INPROG    = NS+':inProgress';
-    const K_BACKUPCFG = NS+':backupConfig';
-
-    const store = {
-      getRaw(key){ try{ const raw = localStorage.getItem(key); return raw ? JSON.parse(raw) : null; }catch{ return null; } },
-      setRaw(key, obj){ localStorage.setItem(key, JSON.stringify(obj)); },
-      get(key, fallback){
-        const obj = store.getRaw(key);
-        if(!obj) return fallback;
-        return ('data' in obj) ? obj.data : obj;
-      },
-      set(key, data){ store.setRaw(key, { v: SCHEMA_VERSION, data }); },
-      getAny(key, fallback){
-        const obj = store.getRaw(key);
-        if(!obj) return fallback;
-        return ('data' in obj) ? obj.data : obj;
-      }
-    };
-
-    const DEFAULTS = {
-      parts: ['胸','背中','肩','腕','脚','腹筋'],
-      equip: ['バーベル','ダンベル','マシン','ケーブル','自重'],
-      attach: ['なし','ストレートバー','Vバー','ロープ','Dハンドル','EZバー'],
-      angle: ['なし','フラット','インクライン','デクライン','ナチュラル'],
-      position: ['なし','ナロー','ミディアム','ワイド','オーバーグリップ','アンダーグリップ','ニュートラル'],
-      exerciseMap: [
-        { name:'ベンチプレス', parts:['胸'] }, { name:'フライ', parts:['胸'] }, { name:'クロスオーバー', parts:['胸'] },
-        { name:'ペックフライ', parts:['胸'] }, { name:'プッシュアップ', parts:['胸'] }, { name:'ディップス', parts:['胸','腕'] },
-        { name:'デッドリフト', parts:['背中','脚'] }, { name:'ローイング', parts:['背中'] }, { name:'ワンハンドロー', parts:['背中'] },
-        { name:'シーテッドロー', parts:['背中'] }, { name:'ラットプルダウン', parts:['背中'] }, { name:'プルアップ', parts:['背中'] },
-        { name:'チンアップ', parts:['背中','腕'] }, { name:'フェイスプル', parts:['背中','肩'] }, { name:'ストレートアームプルダウン', parts:['背中'] },
-        { name:'ショルダープレス', parts:['肩'] }, { name:'サイドレイズ', parts:['肩'] }, { name:'フロントレイズ', parts:['肩'] },
-        { name:'リアレイズ', parts:['肩','背中'] }, { name:'アップライトロー', parts:['肩'] }, { name:'アーノルドプレス', parts:['肩'] },
-        { name:'バイセプスカール', parts:['腕'] }, { name:'ハンマーカール', parts:['腕'] }, { name:'プリーチャーカール', parts:['腕'] },
-        { name:'トライセプスエクステンション', parts:['腕'] }, { name:'オーバーヘッドトライセプスエクステンション', parts:['腕'] }, { name:'スカルクラッシャー', parts:['腕'] },
-        { name:'プレスダウン', parts:['腕'] }, { name:'クローズグリップベンチプレス', parts:['腕','胸'] },
-        { name:'スクワット', parts:['脚'] }, { name:'レッグプレス', parts:['脚'] }, { name:'ハックスクワット', parts:['脚'] },
-        { name:'ブルガリアンスクワット', parts:['脚'] }, { name:'ランジ', parts:['脚'] }, { name:'レッグエクステンション', parts:['脚'] },
-        { name:'レッグカール', parts:['脚'] }, { name:'ルーマニアンデッドリフト', parts:['脚','背中'] }, { name:'ヒップスラスト', parts:['脚'] },
-        { name:'カーフレイズ', parts:['脚'] },
-        { name:'クランチ', parts:['腹筋'] }, { name:'ハンギングレッグレイズ', parts:['腹筋'] }, { name:'ケーブルクランチ', parts:['腹筋'] },
-        { name:'プランク', parts:['腹筋'] }, { name:'アブローラー', parts:['腹筋'] }, { name:'ロシアンツイスト', parts:['腹筋'] },
-        { name:'リバースクランチ', parts:['腹筋'] }
-      ]
-    };
-
-    const state = { lists:null, workouts:null, inProgress:null, chart:null };
-
-    function cleanupExercises(map){
-      const banWords = ['ダンベル','バーベル','ケーブル','インクライン','デクライン','フラット','(ダンベル)','(バーベル)'];
-      const norm = (name)=> banWords.reduce((s,w)=> s.replaceAll(w,''), String(name)).replace(/\s+/g,'').replace(/[（）]/g,'').trim();
-      const out = []; const seen = new Set();
-      (map||[]).forEach(e=>{
-        const n = norm(e.name||'');
-        if(!n) return;
-        if(!seen.has(n)){ seen.add(n); out.push({ name:n, parts:Array.from(new Set(e.parts||[])) }); }
-        else {
-          const idx = out.findIndex(x=> x.name===n);
-          out[idx].parts = Array.from(new Set([...(out[idx].parts||[]), ...(e.parts||[])]));
-        }
-      });
-      return sortExerciseMapJa(out);
-    }
-
-    async function migrateAllIfNeeded(){
-      let lists = store.getAny(K_LISTS, null);
-      if(!lists){ lists = JSON.parse(JSON.stringify(DEFAULTS)); }
-      const uniq = a => Array.from(new Set(a||[]));
-      const putNoneFirst = a => {
-        const arr = uniq(a||[]);
-        const rest = arr.filter(x=>x!=='なし');
-        return ['なし', ...rest];
-      };
-      if(!lists.position) lists.position = DEFAULTS.position.slice();
-      lists.attach   = putNoneFirst(lists.attach || DEFAULTS.attach);
-      lists.angle    = putNoneFirst(lists.angle  || DEFAULTS.angle);
-      lists.position = putNoneFirst(lists.position);
-      lists.exerciseMap = cleanupExercises(lists.exerciseMap || DEFAULTS.exerciseMap);
-      lists.parts     = sortJa(lists.parts || DEFAULTS.parts);
-      lists.equip     = sortJa(lists.equip || DEFAULTS.equip);
-      lists.attach    = sortJa(lists.attach);
-      lists.angle     = sortJa(lists.angle);
-      lists.position  = sortJa(lists.position);
-      store.set(K_LISTS, lists);
-
-      let workouts = store.getAny(K_WORKOUTS, []);
-      workouts.forEach(w=>{
-        (w.blocks||[]).forEach(b=>{
-          if(!b.part && w.part) b.part = w.part;
-          (b.exs||[]).forEach(ex=>{
-            if(ex.pos == null) ex.pos = 'なし';
-            if(ex.att == null) ex.att = 'なし';
-            if(ex.ang == null) ex.ang = 'なし';
-          });
-          (b.sets||[]).forEach(s=>{
-            (s.items||[]).forEach(it=>{
-              if(it.sec == null) it.sec = 0;
-              if(typeof it.oneRM !== 'number') it.oneRM = 0;
-            });
-          });
-        });
-      });
-      store.set(K_WORKOUTS, workouts);
-
-      let inProg = store.getAny(K_INPROG, { date: todayISO(), part:'胸', blocks: [] });
-      if(!inProg.date) inProg.date = todayISO();
-      if(!inProg.part) inProg.part = '胸';
-      if(!Array.isArray(inProg.blocks)) inProg.blocks = [];
-      store.set(K_INPROG, inProg);
-
-      let backupCfg = store.getAny(K_BACKUPCFG, null);
-      if(!backupCfg){
-        backupCfg = { auto:true, frequencyMin:120, lastAt:null, persistGranted:false };
-        store.set(K_BACKUPCFG, backupCfg);
-      }
-    }
-
-    async function requestPersistence(){
-      if(navigator.storage && navigator.storage.persist){
-        try{
-          const granted = await navigator.storage.persist();
-          const cfg = store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false});
-          cfg.persistGranted = !!granted;
-          store.set(K_BACKUPCFG, cfg);
-        }catch{}
-      }
-    }
-
-    async function getBackupConfig(){ return store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false}); }
-    function setBackupConfig(cfg){ store.set(K_BACKUPCFG, cfg); }
-
-    function serializeAll(){
-      return JSON.stringify({
-        version: SCHEMA_VERSION,
-        exportedAt: new Date().toISOString(),
-        lists: store.get(K_LISTS, null),
-        workouts: store.get(K_WORKOUTS, []),
-        inProgress: store.get(K_INPROG, null)
-      });
-    }
-
-    async function backupNow(interactive=false){
-      const cfg = await getBackupConfig();
-      const blob = new Blob([serializeAll()], {type:'application/json'});
-      const fileName = `workout_backup_${todayISO()}.json`;
-
-      try{
-        if (navigator.storage && navigator.storage.getDirectory){
-          const root = await navigator.storage.getDirectory();
-          const handle = await root.getFileHandle('workout_backup.json', { create:true });
-          const ws = await handle.createWritable();
-          await ws.write(blob);
-          await ws.close();
-          const c = store.get(K_BACKUPCFG, cfg); c.lastAt = new Date().toISOString(); store.set(K_BACKUPCFG, c);
-        }
-      }catch(e){
-        console.error('Backup failed:', e);
-      }
-
-      if(navigator.share && interactive){
-        try{
-          const file = new File([blob], fileName, { type:'application/json' });
-          await navigator.share({ files:[file], title:'Workout Backup', text:'バックアップを保存' });
-          const c = store.get(K_BACKUPCFG, cfg); c.lastAt = new Date().toISOString(); store.set(K_BACKUPCFG, c);
-          return true;
-        }catch(e){
-          console.error('Backup failed:', e);
-        }
-      }
-
-      if(interactive){
-        const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
-        a.download = fileName;
-        document.body.appendChild(a); a.click(); a.remove();
-        const c = store.get(K_BACKUPCFG, cfg); c.lastAt = new Date().toISOString(); store.set(K_BACKUPCFG, c);
-      }
-      return true;
-    }
-
-    async function restoreFromFile(){
-      try{
-        if(!window.showOpenFilePicker){ alert('このブラウザはファイル選択APIに未対応です。CSVインポートや共有からファイル取得をご利用ください。'); return; }
-        const [fileHandle] = await window.showOpenFilePicker({ types:[{description:'JSON', accept:{'application/json':['.json']}}] });
-        const file = await fileHandle.getFile();
-        const text = await file.text();
-        const obj = JSON.parse(text);
-        if(!obj.lists || !obj.workouts){ alert('不正なバックアップファイルです。'); return; }
-        store.set(K_LISTS, obj.lists);
-        store.set(K_WORKOUTS, obj.workouts);
-        if(obj.inProgress) store.set(K_INPROG, obj.inProgress);
-        alert('復元しました。再描画します。');
-        renderRoute();
-      }catch(e){
-        console.error('Restore failed:', e);
-        alert('復元に失敗しました');
-      }
-    }
-
-    let _bkTicker = null;
-    function startAutoBackupTicker(){
-      if(_bkTicker) clearInterval(_bkTicker);
-      const cfg = store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false});
-      if(!cfg.auto) return;
-      const ms = Math.max(5, Number(cfg.frequencyMin||120)) * 60 * 1000;
-      _bkTicker = setInterval(()=> backupNow(false), ms);
-    }
-
-    async function afterDataChanged(){
-      requestPersistence();
-      const cfg = await getBackupConfig();
-      if(cfg.auto){ try{ await backupNow(false); }catch{} }
-    }
-
-    function setActiveTab(hash){
-      $$('.tab-btn').forEach(btn=>{
-        const active = btn.getAttribute('data-route') === (hash.startsWith(ROUTES.WORKOUT) ? ROUTES.HOME : hash);
-        btn.classList.toggle('font-bold', active);
-      });
-    }
-    function renderRoute(){
-      const hash = location.hash || ROUTES.HOME;
-      Object.values(VIEWS).forEach(id => { const el = document.querySelector(id); if(el) el.classList.add('hidden'); });
-
-      if(hash.startsWith(ROUTES.HOME))    { document.querySelector(VIEWS.HOME).classList.remove('hidden');    renderHome(); }
-      else if(hash.startsWith(ROUTES.WORKOUT)) { document.querySelector(VIEWS.WORKOUT).classList.remove('hidden'); renderWorkout(); }
-      else if(hash.startsWith(ROUTES.HISTORY)) { document.querySelector(VIEWS.HISTORY).classList.remove('hidden'); renderHistory(); }
-      else                                { document.querySelector(VIEWS.SETTINGS).classList.remove('hidden'); renderSettings(); }
-      setActiveTab(hash);
-    }
-    window.addEventListener('hashchange', renderRoute);
-
-    function calc1RM(weight, reps){
-      const w = Number(weight||0), r = Number(reps||0);
-      if(w<=0 || r<=0) return 0;
-      return Math.round(w * (1 + r/30) * 10) / 10;
-    }
-    function computeTrainingDays(rangeDays){
-      const cutoff = Date.now() - rangeDays*24*3600*1000;
-      const days = new Set(store.get(K_WORKOUTS, []).filter(w => new Date(w.date||todayISO()).getTime() >= cutoff).map(w => w.date||todayISO()));
-      return days.size;
-    }
-
-    function initData(){
-      state.lists = store.get(K_LISTS, JSON.parse(JSON.stringify(DEFAULTS)));
-      state.workouts = store.get(K_WORKOUTS, []);
-      state.inProgress = store.get(K_INPROG, { date: todayISO(), part: '胸', blocks: [] });
-      if(!state.inProgress.date) state.inProgress.date = todayISO();
-      if(!state.inProgress.blocks) state.inProgress.blocks = [];
-    }
-    function persist(){
-      store.set(K_LISTS, state.lists);
-      store.set(K_WORKOUTS, state.workouts);
-      store.set(K_INPROG, state.inProgress);
-    }
-
-    /* DASHBOARD */
-    function renderHome(){
-      const dateEl = $('#inp-date');
-      dateEl.value = state.inProgress.date || todayISO();
-      dateEl.onchange = (e)=> { state.inProgress.date = e.target.value || todayISO(); persist(); afterDataChanged(); };
-
-      $('#stat-week').textContent = computeTrainingDays(7);
-      $('#stat-month').textContent = computeTrainingDays(30);
-
-      $$('.part-btn').forEach(b=>{
-        const active = state.inProgress.part === b.dataset.part;
-        b.classList.toggle('bg-gray-900', active);
-        b.classList.toggle('text-white', active);
-        b.classList.toggle('bg-white', !active);
-        b.classList.toggle('text-gray-900', !active);
-        b.onclick = ()=>{ state.inProgress.part = b.dataset.part; persist(); renderHome(); };
-      });
-
-      const btn = $('#btn-start-or-resume');
-      if (btn) {
-        const hasBlocks = (state.inProgress.blocks||[]).length > 0;
-        btn.textContent = hasBlocks ? 'トレーニングを再開' : '今日のトレーニングを開始';
-        btn.onclick = ()=> { location.hash = ROUTES.WORKOUT; };
-      }
-    }
-
-    /* WORKOUT */
-    function renderWorkout(){
-      $('#workout-date').textContent = state.inProgress.date || todayISO();
-      $('#workout-part').textContent = state.inProgress.part || '-';
-      $('#btn-back-to-home').onclick = ()=> { location.hash = ROUTES.HOME; };
-      $('#btn-save-workout').onclick = ()=> { saveWorkout(); location.hash = ROUTES.HOME; };
-      $('#btn-add-block').onclick = addBlock;
-      const wrap = $('#blocks');
-      wrap.innerHTML = '';
-      (state.inProgress.blocks||[]).forEach((block, idx)=> wrap.appendChild(renderBlock(block, idx)));
-    }
-    /* Builders */
-    function renderBlock(block, idx){
-      const frag = document.importNode($('#tpl-block').content, true);
-      frag.querySelector('.block-index').textContent = '#'+(idx+1);
-      frag.querySelector('.block-part').textContent = `（${block.part || state.inProgress.part}）`;
-
-      frag.querySelector('.btn-choose-ex').onclick = ()=> openExerciseChooser(idx);
-      frag.querySelector('.btn-del-block').onclick = async ()=>{
-        if(await confirmAction('ブロックを削除しますか？')){
-          state.inProgress.blocks.splice(idx,1);
-          persist(); renderWorkout(); afterDataChanged();
-        }
-      };
-
-      const cfgWrap = frag.querySelector('.ex-config');
-      (block.exs||[]).forEach(ex=> cfgWrap.appendChild(renderExConfigRow(block, ex)));
-
-      const setWrap = frag.querySelector('.set-list');
-      frag.querySelector('.btn-add-set').onclick = ()=> { addSet(block, true); };
-      frag.querySelector('.btn-clear-sets').onclick = async ()=>{
-        if(await confirmAction('このブロックの全セットを削除しますか？')){
-          block.sets = []; persist(); renderWorkout(); afterDataChanged();
-        }
-      };
-      (block.sets||[]).forEach((set, sIdx)=> setWrap.appendChild(renderSetCard(block, set, sIdx)));
-
-      return frag;
-    }
-
-    function addBlock(){
-      state.inProgress.blocks.push({ part: state.inProgress.part, exs: [], sets: [] });
-      persist(); renderWorkout();
-      setTimeout(()=> window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' }), 0);
-      const idx = state.inProgress.blocks.length - 1;
-      setTimeout(()=> openExerciseChooser(idx), 50);
-    }
-
-    function openExerciseChooser(blockIdx){
-      const part = state.inProgress.blocks[blockIdx].part || state.inProgress.part;
-      const allowed = sortJa(state.lists.exerciseMap.filter(e=> (e.parts||[]).includes(part)).map(e=> e.name));
-      const current = new Set((state.inProgress.blocks[blockIdx].exs||[]).map(e=> e.name));
-
-      const bg = document.createElement('div'); bg.className='modal-bg flex items-center justify-center z-50';
-      const card = document.createElement('div'); card.className='modal-card bg-white rounded-2xl p-4 shadow-soft border w-[92vw]';
-      const head = document.createElement('div'); head.className='text-sm font-semibold mb-2'; head.textContent = `種目選択（${part}）`;
-      const list = document.createElement('div'); list.className='max-h-[60vh] overflow-auto space-y-1';
-
-      if(allowed.length===0){
-        const msg=document.createElement('div'); msg.className='text-sm text-gray-500';
-        msg.textContent='この部位に紐づく種目がありません。設定＞種目マスタで追加してください。';
-        list.appendChild(msg);
-      }else{
-        allowed.forEach(name=>{
-          const row=document.createElement('label'); row.className='flex items-center gap-2 text-sm';
-          const cb=document.createElement('input'); cb.type='checkbox'; cb.checked=current.has(name);
-          cb.dataset.name=name; cb.dataset.checkedAt='';
-          cb.addEventListener('change', ()=>{ cb.dataset.checkedAt = cb.checked ? String(Date.now()+Math.random()) : ''; });
-          const sp=document.createElement('span'); sp.textContent=name;
-          row.append(cb,sp); list.appendChild(row);
-        });
-      }
-
-      const actions=document.createElement('div'); actions.className='flex justify-end gap-2 mt-3';
-      const btnCancel=document.createElement('button'); btnCancel.className='px-3 py-2 rounded-xl bg-white border'; btnCancel.textContent='キャンセル';
-      const btnOk=document.createElement('button'); btnOk.className='px-3 py-2 rounded-xl bg-gray-900 text-white'; btnOk.textContent='OK';
-      actions.append(btnCancel, btnOk);
-
-      card.append(head, list, actions); bg.appendChild(card); document.body.appendChild(bg);
-      btnCancel.onclick=()=> bg.remove();
-      btnOk.onclick=()=>{
-        const cbs = Array.from(list.querySelectorAll('input[type=checkbox]:checked'));
-        // チェック順（checkedAtが無い場合はDOM順のまま）
-        cbs.sort((a,b)=>{
-          const ta=a.dataset.checkedAt, tb=b.dataset.checkedAt;
-          if(ta && tb) return ta.localeCompare(tb);
-          if(ta) return -1; if(tb) return 1; return 0;
-        });
-        const names = cbs.map(cb=> cb.dataset.name);
-        applySelectedExercises(blockIdx, names);
-        bg.remove();
-      };
-      bg.addEventListener('click', e=>{ if(e.target===bg) bg.remove(); });
-    }
-
-    function applySelectedExercises(blockIdx, names){
-      const block = state.inProgress.blocks[blockIdx];
-      const before = block.exs || [];
-
-      // 選択順のまま exs を構築（既存があれば使い回し）
-      block.exs = names.map(name => before.find(e=> e.name===name) || { name, eq: state.lists.equip[0]||'', att:'なし', ang:'なし', pos:'なし' });
-
-      // 既存セットの items も同順で並び替え/補完
-      (block.sets||[]).forEach(s=>{
-        const prevItems = s.items||[];
-        s.items = names.map(name=>{
-          const prevIdx = before.findIndex(e=> e.name===name);
-          return (prevIdx>=0 && prevItems[prevIdx]) ? prevItems[prevIdx] : { w:0, reps:0, assist:0, note:'', oneRM:0 };
-        });
-      });
-
-      // セット未作成なら1セット目を作る
-      if(!block.sets || block.sets.length===0){
-        block.sets = [{ warm:false, items: names.map(()=> ({ w:0, reps:0, assist:0, note:'', oneRM:0 })) }];
-      }
-
-      persist(); renderWorkout(); afterDataChanged && afterDataChanged();
-    }
-
-    function renderExConfigRow(block, ex){
-      const node = document.importNode($('#tpl-ex-config-row').content, true);
-      node.querySelector('.ex-name').textContent = ex.name;
-
-      // ▲/▼（テンプレに無い場合は非表示になるだけ）
-      const up = node.querySelector('.ex-move-up');
-      const down = node.querySelector('.ex-move-down');
-      if(up) up.onclick = ()=>{
-        const idx = block.exs.findIndex(e=> e===ex);
-        if(idx<=0) return;
-        [block.exs[idx-1], block.exs[idx]] = [block.exs[idx], block.exs[idx-1]];
-        (block.sets||[]).forEach(s=> [s.items[idx-1], s.items[idx]] = [s.items[idx], s.items[idx-1]]);
-        persist(); renderWorkout();
-      };
-      if(down) down.onclick = ()=>{
-        const idx = block.exs.findIndex(e=> e===ex);
-        if(idx>=block.exs.length-1) return;
-        [block.exs[idx+1], block.exs[idx]] = [block.exs[idx], block.exs[idx+1]];
-        (block.sets||[]).forEach(s=> [s.items[idx+1], s.items[idx]] = [s.items[idx], s.items[idx+1]]);
-        persist(); renderWorkout();
-      };
-
-      // 「なし」を先頭固定で描画
-      const fill = (sel, arr, val, cb)=>{
-        sel.innerHTML=''; orderWithNoneFirst(arr).forEach(v=> {
-          const o=document.createElement('option'); o.value=v; o.textContent=v; sel.appendChild(o);
-        });
-        sel.value = val || 'なし';
-        sel.onchange = e=> cb(e.target.value);
-      };
-      fill(node.querySelector('.ex-eq'),  state.lists.equip,    ex.eq || state.lists.equip[0], v=>{ ex.eq=v; persist(); });
-      fill(node.querySelector('.ex-att'), state.lists.attach,   ex.att || 'なし',               v=>{ ex.att=v; persist(); });
-      fill(node.querySelector('.ex-ang'), state.lists.angle,    ex.ang || 'なし',               v=>{ ex.ang=v; persist(); });
-      fill(node.querySelector('.ex-pos'), state.lists.position, ex.pos || 'なし',               v=>{ ex.pos=v; persist(); });
-
-      updateExMetaLine(node, ex);
-      return node;
-    }
-
-    function updateExMetaLine(rowNode, ex){
-      const meta = rowNode.querySelector('.ex-meta');
-      const all = flattenSets().filter(r=> r.exercise===ex.name);
-      if(all.length===0){ meta.textContent='最高重量: - / 最高1RM: - / 前回: -'; return; }
-      const maxW = Math.max(...all.map(r=> Number(r.weight||0)));
-      const max1 = Math.max(...all.map(r=> Number(r.oneRM||0)));
-      const last = all.sort((a,b)=> a.date<b.date ? 1 : -1)[0];
-      meta.textContent = `最高重量: ${maxW||'-'} / 最高1RM: ${max1||'-'} / 前回: ${last ? last.date : '-'}`;
-    }
-
-    function renderSetCard(block, set, sIdx){
-      const node = document.importNode($('#tpl-set-card').content, true);
-      node.querySelector('.set-no').textContent = '#'+(sIdx+1);
-      const warm = node.querySelector('.set-warm');
-      warm.checked = !!set.warm;
-      warm.addEventListener('input', ()=> { set.warm = warm.checked; persist(); afterDataChanged(); });
-
-      const itemsWrap = node.querySelector('.ex-items');
-      ensureSetItems(block, set);
-      (block.exs||[]).forEach((ex, i)=> itemsWrap.appendChild(renderExItemRow(block, set, i, ex)));
-
-      node.querySelector('.btn-dup-set').onclick = ()=> {
-        const source = block.sets[sIdx];
-        const cloned = JSON.parse(JSON.stringify(source));
-        block.sets.splice(sIdx+1, 0, cloned);
-        persist(); renderWorkout(); afterDataChanged();
-      };
-      node.querySelector('.btn-del-set').onclick = ()=> {
-        block.sets.splice(sIdx,1);
-        persist(); renderWorkout(); afterDataChanged();
-      };
-      return node;
-    }
-
-    function ensureSetItems(block, set){
-      if(!set.items) set.items = [];
-      const need = (block.exs||[]).length;
-      if(set.items.length < need){
-        const last = set.items[set.items.length-1] || { w:0, reps:0, assist:0, note:'', oneRM:0, sec:0 };
-        for(let i=set.items.length; i<need; i++){ set.items[i] = { ...last }; }
-      } else if(set.items.length > need){
-        set.items = set.items.slice(0, need);
-      }
-    }
-
-    function addSet(block, copyLast){
-      if(!block.sets) block.sets = [];
-      if(copyLast && block.sets.length){
-        const last = block.sets[block.sets.length-1];
-        const cloned = JSON.parse(JSON.stringify(last));
-        block.sets.push(cloned);
-      } else {
-        const items = (block.exs||[]).map(()=> ({ w:0, reps:0, assist:0, note:'', oneRM:0, sec:0 }));
-        block.sets.push({ warm:false, items });
-      }
-      persist(); renderWorkout(); afterDataChanged();
-      setTimeout(()=> window.scrollTo({ top: document.body.scrollHeight, behavior:'smooth' }), 0);
-    }
-
-    function renderExItemRow(block, set, idx, ex){
-      const node = document.importNode($('#tpl-ex-item-row').content, true);
-      const item = set.items[idx] ||= { w:0, reps:0, assist:0, note:'', oneRM:0, sec:0 };
-
-      // 見出し：実際の種目名
-      const titleEl = node.querySelector('.ex-title');
-      if(titleEl) titleEl.textContent = ex.name;
-
-      // 入力
-      const elW = node.querySelector('.ex-weight');
-      const elR = node.querySelector('.ex-reps');
-      const elA = node.querySelector('.ex-assist');
-      const elN = node.querySelector('.ex-note');
-      const elOne = node.querySelector('.ex-1rm');
-      const elSec = node.querySelector('.ex-sec'); // 秒入力は残す（手入力用）
-
-      elW.value = item.w || '';
-      elR.value = item.reps || '';
-      elA.value = item.assist || '';
-      elN.value = item.note || '';
-      if(elSec) elSec.value = item.sec || '';
-
-      const recalc = debounce(()=>{
-        const w = Number(elW.value||0), r = Number(elR.value||0);
-        item.w = w; item.reps = r; item.assist = Number(elA.value||0); item.note = elN.value || '';
-        if(elSec){ item.sec = Number(elSec.value||0); }
-        item.oneRM = (w>0 && r>0) ? Math.round(w * (1 + r/30) * 10)/10 : 0;
-        elOne.textContent = item.oneRM || '-';
-        persist();
-      }, 120);
-
-      [elW, elR, elA, elN].forEach(el => el && el.addEventListener('input', recalc));
-      if(elSec) elSec.addEventListener('input', recalc);
-
-      // タイマーボタン（▶/■）は廃止：テンプレに残っていても何もしない
-      const toggle = node.querySelector('.ex-sec-toggle');
-      if(toggle) toggle.remove();
-
-      elOne.textContent = item.oneRM || '-';
-      return node;
-    }
-
-    /* Save workout & history */
-    function saveWorkout(){
-      const copy = JSON.parse(JSON.stringify(state.inProgress));
-      copy.blocks.forEach(b=>{
-        b.sets = (b.sets||[]).map(s=>{
-          s.items = (s.items||[]).filter(it=>{
-            return (Number(it.sec)>0) || (Number(it.w)>0 && Number(it.reps)>0) || it.note;
-          });
-          return s;
-        }).filter(s=> s.items.length>0);
-      });
-      copy.blocks = copy.blocks.filter(b=> (b.exs||[]).length>0 && (b.sets||[]).length>0);
-      if(copy.blocks.length===0){ alert('記録が空です。セットを入力してください。'); return; }
-      copy.id = 'w_'+Date.now();
-      state.workouts.push(copy);
-      state.inProgress = { date: state.inProgress.date || todayISO(), part: state.inProgress.part, blocks: [] };
-      persist(); alert('保存しました'); afterDataChanged();
-    }
-
-    function flattenSets(){
-      const rows = [];
-      (store.get(K_WORKOUTS, [])).forEach(w=>{
-        (w.blocks||[]).forEach(b=>{
-          (b.sets||[]).forEach((s, sIdx)=>{
-            (b.exs||[]).forEach((ex, exIdx)=>{
-              const it = (s.items||[])[exIdx] || {};
-              rows.push({
-                id: w.id, date: w.date || state.inProgress.date || todayISO(), part: b.part || '不明',
-                exercise: ex.name, equipment: ex.eq||'', attachment: ex.att||'なし',
-                angle: ex.ang||'なし', position: ex.pos||'なし', setIndex: sIdx+1,
-                warmup: !!s.warm, weight: Number(it.w||0), repsSelf: Number(it.reps||0),
-                repsAssist: Number(it.assist||0), durationSec: Number(it.sec||0), note: it.note||'',
-                oneRM: Number(it.oneRM||0)
-              });
-            });
-          });
-        });
-      });
-      return rows.sort((a,b)=> a.date<b.date ? -1 : 1);
-    }
-
-    function renderHistory(){
-      const parts = ['(指定なし)', ...sortJa(state.lists.parts)];
-      const exs   = ['(指定なし)', ...sortJa(Array.from(new Set(flattenSets().map(r=> r.exercise))))];
-      const eqs   = ['(指定なし)', ...sortJa(state.lists.equip)];
-      const atts  = ['(指定なし)', ...orderWithNoneFirst(state.lists.attach)];
-      const angs  = ['(指定なし)', ...orderWithNoneFirst(state.lists.angle)];
-      const poss  = ['(指定なし)', ...orderWithNoneFirst(state.lists.position)];
-      const fillSel=(id,arr)=>{ const el=$(id); if(!el) return; el.innerHTML=''; arr.forEach(v=>{ const o=document.createElement('option'); o.value=v;o.textContent=v; el.appendChild(o); }); };
-      fillSel('#filter-part',parts); fillSel('#filter-ex',exs); fillSel('#filter-eq',eqs);
-      fillSel('#filter-att',atts);   fillSel('#filter-ang',angs); fillSel('#filter-pos',poss);
-
-      $('#btn-apply-filter').onclick = ()=> applyFilter();
-      $('#btn-clear-filter').onclick = ()=> {
-        $('#filter-start').value=''; $('#filter-end').value='';
-        ['part','ex','eq','att','ang','pos'].forEach(id=> $('#filter-'+id).value='(指定なし)');
-        applyFilter();
-      };
-
-      const params = new URLSearchParams(location.hash.split('?')[1] || '');
-      const exParam = params.get('exercise');
-      if(exParam){ $('#filter-ex').value = exParam; }
-      applyFilter();
-    }
-
-    function applyFilter(){
-      const start = $('#filter-start').value;
-      const end = $('#filter-end').value;
-      const part = $('#filter-part').value;
-      const ex = $('#filter-ex').value;
-      const eq = $('#filter-eq').value;
-      const att = $('#filter-att').value;
-      const ang = $('#filter-ang').value;
-      const pos = $('#filter-pos').value;
-
-      let rows = flattenSets();
-      if(start) rows = rows.filter(r => r.date >= start);
-      if(end) rows = rows.filter(r => r.date <= end);
-      if(part && part!=='(指定なし)') rows = rows.filter(r => r.part===part);
-      if(ex && ex!=='(指定なし)') rows = rows.filter(r => r.exercise===ex);
-      if(eq && eq!=='(指定なし)') rows = rows.filter(r => r.equipment===eq);
-      if(att && att!=='(指定なし)') rows = rows.filter(r => r.attachment===att);
-      if(ang && ang!=='(指定なし)') rows = rows.filter(r => r.angle===ang);
-      if(pos && pos!=='(指定なし)') rows = rows.filter(r => r.position===pos);
-
-      renderHistoryList(rows);
-      if(ex && ex!=='(指定なし)'){
-        const dailyMax = aggregateDailyMax1RM(rows);
-        renderChart(dailyMax.labels, dailyMax.values, true);
-      } else { renderChart([], [], false); }
-    }
-
-    function aggregateDailyMax1RM(rows){
-      const map = new Map();
-      rows.forEach(r=>{
-        const key = r.date;
-        const prev = map.get(key) || 0;
-        map.set(key, Math.max(prev, r.oneRM||0));
-      });
-      const labels = Array.from(map.keys()).sort();
-      const values = labels.map(d => map.get(d));
-      return { labels, values };
-    }
-
-    function renderHistoryList(rows){
-      const list = $('#history-list');
-      list.innerHTML = '';
-      if(rows.length===0){ list.innerHTML = '<div class="text-sm text-gray-500">データがありません。</div>'; return; }
-
-      const byWorkout = rows.reduce((acc, r)=> { (acc[r.id] ||= []).push(r); return acc; }, {});
-      Object.values(byWorkout).forEach(items=>{
-        const w = items[0];
-        const card = document.createElement('div');
-        card.className = 'rounded-2xl border bg-white p-3 shadow-soft';
-        const partsInWorkout = Array.from(new Set(items.map(i=>i.part))).join(' / ');
-        const title = document.createElement('div');
-        title.className = 'flex items-center justify-between';
-        title.innerHTML = `<div class="text-sm font-semibold">${w.date} / ${partsInWorkout}</div>`;
-        card.appendChild(title);
-        items.forEach(r=>{
-          const timeLabel = r.durationSec ? ` / 時間 ${r.durationSec}s` : '';
-          const row = document.createElement('div');
-          row.className = 'mt-2 text-sm grid grid-cols-12 gap-1';
-          row.innerHTML = `
-            <div class="col-span-6 truncate-2">${r.exercise} <span class="text-xs text-gray-500">(${r.equipment} / ${r.attachment} / ${r.angle} / ${r.position})</span></div>
-            <div class="col-span-3">重量 ${r.weight}kg</div>
-            <div class="col-span-1">自 ${r.repsSelf}</div>
-            <div class="col-span-2">補 ${r.repsAssist}</div>
-            <div class="col-span-12 text-[11px] text-gray-500">部位:${r.part}${timeLabel} / 1RM:${r.oneRM || '-'}kg / S${r.setIndex} ${r.note ? ' / '+escapeHtml(r.note) : ''}</div>
-          `;
-          card.appendChild(row);
-        });
-        list.appendChild(card);
-      });
-
-      const params = new URLSearchParams(location.hash.split('?')[1] || '');
-      const exParam = params.get('exercise');
-      const backBtn = $('#btn-back-to-home-from-simple');
-      if(backBtn){ backBtn.classList.toggle('hidden', !exParam); backBtn.onclick = ()=> { location.hash = '#/workout'; }; }
-    }
-
-    function renderChart(labels, values, show){
-      const wrap = $('#history-chart-wrap');
-      wrap.classList.toggle('hidden', !show);
-      if(!show){ if(state.chart){ state.chart.destroy(); state.chart=null; } return; }
-      const ctx = $('#history-chart').getContext('2d');
-      if(state.chart) state.chart.destroy();
-      state.chart = new Chart(ctx, {
-        type: 'line',
-        data: { labels, datasets: [{ label: '1RM (kg)', data: values, tension: 0.25, pointRadius: 3 }] },
-        options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
-      });
-    }
-
-    /* SETTINGS */
-    function renderSettings(){
-      $('#list-parts').value = sortJa(state.lists.parts).join('\n');
-      $('#list-equip').value = sortJa(state.lists.equip).join('\n');
-      $('#list-attach').value = sortJa(state.lists.attach).join('\n');
-      $('#list-angle').value = sortJa(state.lists.angle).join('\n');
-      $('#list-position').value = sortJa(state.lists.position).join('\n');
-
-      const boxes = $('#part-boxes');
-      boxes.innerHTML = '';
-      const parts = sortJa(state.lists.parts);
-
-      parts.forEach(part=>{
-        const card = document.createElement('div');
-        card.className = 'rounded-xl border p-3 bg-white shadow-soft';
-        const head = document.createElement('div');
-        head.className = 'flex items-center justify-between mb-2';
-        head.innerHTML = `<div class="text-sm font-semibold">${part} の種目</div>`;
-        const addBtn = document.createElement('button');
-        addBtn.className = 'px-2 py-1.5 rounded-md border text-xs';
-        addBtn.textContent = '追加';
-        head.appendChild(addBtn);
-        card.appendChild(head);
-
-        const list = document.createElement('div');
-        list.className = 'space-y-1';
-        card.appendChild(list);
-
-        function refreshList(){
-          list.innerHTML = '';
-          const rows = sortExerciseMapJa(state.lists.exerciseMap).filter(e=> (e.parts||[]).includes(part));
-          if(rows.length===0){
-            list.innerHTML = `<div class="text-xs text-gray-500">まだありません。</div>`;
-          }else{
-            rows.forEach(row=> list.appendChild(renderExerciseRowByPart(row, part, refreshList)));
-          }
-        }
-
-        addBtn.onclick = async ()=>{
-          const name = await promptModal('新しい種目名を入力（器具名・角度名は含めない）');
-          if(!name) return;
-          const clean = cleanupExercises([{name, parts:[part]}])[0];
-          if(!clean) return;
-          const idx = state.lists.exerciseMap.findIndex(e=> e.name===clean.name);
-          if(idx>=0){
-            const pset = new Set(state.lists.exerciseMap[idx].parts||[]);
-            pset.add(part);
-            state.lists.exerciseMap[idx].parts = Array.from(pset);
-          }else{
-            state.lists.exerciseMap.push({ name: clean.name, parts:[part] });
-          }
-          state.lists.exerciseMap = sortExerciseMapJa(state.lists.exerciseMap);
-          persist(); refreshList(); afterDataChanged();
-        };
-
-        refreshList();
-        boxes.appendChild(card);
-      });
-
-      $('#btn-save-lists').onclick = ()=> { saveLists(); };
-      $('#btn-reset-defaults').onclick = ()=> { resetDefaults(); };
-
-      const cfg = store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false});
-      const elAuto = document.getElementById('bk-auto');
-      const elFreq = document.getElementById('bk-frequency');
-      const elLast = document.getElementById('bk-last');
-      if(elAuto){ elAuto.checked = !!cfg.auto; elAuto.onchange = ()=> { const c=store.get(K_BACKUPCFG,cfg); c.auto = elAuto.checked; store.set(K_BACKUPCFG,c); startAutoBackupTicker(); }; }
-      if(elFreq){ elFreq.value = cfg.frequencyMin || 120; elFreq.oninput = ()=> { const c=store.get(K_BACKUPCFG,cfg); c.frequencyMin = Math.max(5, Number(elFreq.value||120)); store.set(K_BACKUPCFG,c); startAutoBackupTicker(); }; }
-      if(elLast){ elLast.textContent = cfg.lastAt ? new Date(cfg.lastAt).toLocaleString() : '-'; }
-      const chooseBtn = document.getElementById('bk-choose');
-      if(chooseBtn){ chooseBtn.onclick = ()=> alert('OPFSに自動保存します。iCloudへは「今すぐバックアップ」を使い、共有シートからFiles(iCloud Drive)に保存してください。'); }
-      const nowBtn = document.getElementById('bk-now');
-      if(nowBtn){ nowBtn.onclick = async ()=> { await backupNow(true); const c=store.get(K_BACKUPCFG, {}); const elLast=document.getElementById('bk-last'); if(elLast){ elLast.textContent = c.lastAt ? new Date(c.lastAt).toLocaleString() : '-'; } }; }
-      const restoreBtn = document.getElementById('bk-restore');
-      if(restoreBtn){ restoreBtn.onclick = async ()=> { await restoreFromFile(); }; }
-    }
-
-    function renderExerciseRowByPart(row, part, refresh){
-      const wrap = document.createElement('div');
-      wrap.className = 'grid grid-cols-12 gap-1 items-center';
-      const nameCol = document.createElement('div');
-      nameCol.className = 'col-span-7';
-      const ipt = document.createElement('input');
-      ipt.type = 'text';
-      ipt.className = 'w-full border rounded px-2 py-1 text-sm';
-      ipt.value = row.name;
-      nameCol.appendChild(ipt);
-
-      const btns = document.createElement('div');
-      btns.className = 'col-span-5 flex justify-end gap-2';
-      const btnSave = document.createElement('button');
-      btnSave.className = 'px-2 py-1.5 rounded-md border text-xs';
-      btnSave.textContent = '名称更新';
-      const btnDel = document.createElement('button');
-      btnDel.className = 'px-2 py-1.5 rounded-md border text-xs text-red-700 border-red-200';
-      btnDel.textContent = '削除';
-
-      btns.appendChild(btnSave);
-      btns.appendChild(btnDel);
-
-      btnSave.onclick = ()=>{
-        const newNameRaw = ipt.value.trim();
-        if(!newNameRaw) return;
-        const cleaned = cleanupExercises([{name:newNameRaw, parts:row.parts}])[0];
-        if(!cleaned) return;
-        const idxOther = state.lists.exerciseMap.findIndex(e=> e.name===cleaned.name);
-        const idxSelf  = state.lists.exerciseMap.findIndex(e=> e.name===row.name);
-        if(idxOther>=0 && idxOther!==idxSelf){
-          const merged = Array.from(new Set([...(state.lists.exerciseMap[idxOther].parts||[]), ...(state.lists.exerciseMap[idxSelf].parts||[])]));
-          state.lists.exerciseMap[idxOther].parts = merged;
-          state.lists.exerciseMap.splice(idxSelf,1);
-        }else{
-          state.lists.exerciseMap[idxSelf].name = cleaned.name;
-        }
-        state.lists.exerciseMap = sortExerciseMapJa(state.lists.exerciseMap);
-        persist(); refresh(); afterDataChanged();
-      };
-
-      btnDel.onclick = async ()=>{
-        const ok = await confirmAction(`「${row.name}」を${part}から削除します。よろしいですか？（他の部位に属していない場合は種目自体が削除されます）`);
-        if(!ok) return;
-        const idx = state.lists.exerciseMap.findIndex(e=> e.name===row.name);
-        if(idx<0) return;
-        const p = new Set(state.lists.exerciseMap[idx].parts||[]);
-        p.delete(part);
-        const newParts = Array.from(p);
-        if(newParts.length===0){
-          const ok2 = await confirmAction(`「${row.name}」はどの部位にも属さなくなります。種目自体を削除します。よろしいですか？`);
-          if(!ok2) return;
-          state.lists.exerciseMap.splice(idx,1);
-        }else{
-          state.lists.exerciseMap[idx].parts = newParts;
-        }
-        persist(); refresh(); afterDataChanged();
-      };
-
-      wrap.appendChild(nameCol);
-      wrap.appendChild(btns);
-      return wrap;
-    }
-
-    function saveLists(){
-      const parseLines = v => v.split('\n').map(s=>s.trim()).filter(Boolean);
-      state.lists.parts = sortJa(parseLines($('#list-parts').value));
-      state.lists.equip = sortJa(parseLines($('#list-equip').value));
-      state.lists.attach = sortJa(parseLines($('#list-attach').value));
-      if(state.lists.attach[0] !== 'なし'){ state.lists.attach = ['なし', ...state.lists.attach.filter(x=>x!=='なし')]; }
-      state.lists.angle = sortJa(parseLines($('#list-angle').value));
-      if(state.lists.angle[0] !== 'なし'){ state.lists.angle = ['なし', ...state.lists.angle.filter(x=>x!=='なし')]; }
-      state.lists.position = sortJa(parseLines($('#list-position').value));
-      if(state.lists.position[0] !== 'なし'){ state.lists.position = ['なし', ...state.lists.position.filter(x=>x!=='なし')]; }
-
-      state.lists.exerciseMap = cleanupExercises(sortExerciseMapJa(
-        state.lists.exerciseMap.filter(r=> (r.name && r.name.trim().length>0))
-      ));
-
-      persist();
-      alert('保存しました');
-      if(location.hash.startsWith(ROUTES.HOME)) renderHome();
-      afterDataChanged();
-    }
-
-    function resetDefaults(){
-      state.lists = JSON.parse(JSON.stringify(DEFAULTS));
-      state.lists.parts = sortJa(state.lists.parts);
-      state.lists.equip = sortJa(state.lists.equip);
-      state.lists.attach = sortJa(state.lists.attach);
-      state.lists.angle = sortJa(state.lists.angle);
-      state.lists.position = sortJa(state.lists.position);
-      state.lists.exerciseMap = cleanupExercises(sortExerciseMapJa(state.lists.exerciseMap));
-      persist(); renderSettings(); alert('デフォルトに復元しました'); afterDataChanged();
-    }
-
-    function exportCSV(){
-      const rows = flattenSets().map(r=>[
-        r.date, r.part, r.exercise, r.equipment, r.attachment, r.angle, r.position,
-        r.setIndex, r.warmup ? 1 : 0, r.weight, r.repsSelf, r.repsAssist, r.durationSec, r.note, r.oneRM
-      ]);
-      rows.unshift(['date','part','exercise','equipment','attachment','angle','position','setIndex','warmup','weight','repsSelf','repsAssist','durationSec','note','oneRM']);
-      const blob = new Blob([toCSV(rows)], {type:'text/csv;charset=utf-8;'});
-      const a = document.createElement('a');
-      a.href = URL.createObjectURL(blob);
-      a.download = `workouts_${todayISO()}.csv`;
-      document.body.appendChild(a); a.click(); a.remove();
-    }
-
-    function importCSV(file){
-      const reader = new FileReader();
-      reader.onload = ()=>{
-        const text = reader.result;
-        const rows = parseCSV(text);
-        const header = rows.shift() || [];
-        const idx = name => header.indexOf(name);
-        const dateI=idx('date'), partI=idx('part'), exI=idx('exercise'), eqI=idx('equipment'), attI=idx('attachment'), angI=idx('angle'), posI=idx('position'),
-              sI=idx('setIndex'), warmI=idx('warmup'), wI=idx('weight'), rsI=idx('repsSelf'), raI=idx('repsAssist'), durI=idx('durationSec'), noteI=idx('note'), oneI=idx('oneRM');
-        if(dateI<0 || partI<0 || exI<0){ alert('CSVヘッダが不正です'); return; }
-
-        const groups = {};
-        rows.forEach(r=>{
-          const date = r[dateI]; if(!date) return;
-          const part = r[partI] || '不明';
-          const key = date+'|'+part;
-          (groups[key] ||= []).push({
-            exercise: r[exI]||'', equipment: r[eqI]||'', attachment: r[attI]||'なし',
-            angle: r[angI]||'なし', position: r[posI]||'なし', setIndex: Number(r[sI]||1),
-            warmup: Number(r[warmI]||0)>0, weight: Number(r[wI]||0), repsSelf: Number(r[rsI]||0),
-            repsAssist: Number(r[raI]||0), durationSec: Number(r[durI]||0), note: r[noteI]||'',
-            oneRM: Number(r[oneI]||0)
-          });
-        });
-
-        Object.entries(groups).forEach(([key, items])=>{
-          const [date, part] = key.split('|');
-          const exNames = Array.from(new Set(items.map(it=> it.exercise)));
-          const maxSet = Math.max(0, ...items.map(it=> it.setIndex||0));
-          const exs = exNames.map(name=>{
-            const any = items.find(it=> it.exercise===name) || {};
-            const cleanedName = cleanupExercises([{name, parts:[]}])[0]?.name || name;
-            return { name: cleanedName, eq:any.equipment||'', att:any.attachment||'なし', ang:any.angle||'なし', pos:any.position||'なし' };
-          });
-          const sets = [];
-          for(let s=1; s<=Math.max(1, maxSet); s++){
-            const set = { warm:false, items: exNames.map(()=> ({ w:0,reps:0,assist:0,sec:0,note:'',oneRM:0 })) };
-            exNames.forEach((name, i)=>{
-              const it = items.find(it=> it.exercise===name && it.setIndex===s);
-              if(it){
-                set.warm = set.warm || !!it.warmup;
-                set.items[i] = { w:it.weight, reps:it.repsSelf, assist:it.repsAssist, sec:it.durationSec||0, note:it.note, oneRM: it.durationSec>0?0:(it.oneRM||calc1RM(it.weight,it.repsSelf)) };
-              }
-            });
-            sets.push(set);
-          }
-          state.workouts.push({ id:'w_'+Date.now()+Math.random(), date, blocks:[{ part, exs, sets }] });
-        });
-
-        persist(); alert('インポート完了'); if(location.hash.startsWith(ROUTES.HISTORY)) renderHistory(); afterDataChanged();
-      };
-      reader.readAsText(file);
-    }
-
-    function parseCSV(text){
-      const rows = []; let i=0, field='', row=[], inQ=false;
-      while(i<text.length){
-        const c=text[i++];
-        if(inQ){ if(c=== '"'){ if(text[i]==='"'){ field+='"'; i++; } else { inQ=false; } } else { field+=c; } }
-        else { if(c===','){ row.push(field); field=''; } else if(c==='"'){ inQ=true; } else if(c==='\n'){ row.push(field); rows.push(row); row=[]; field=''; } else if(c!=='\r'){ field+=c; } }
-      }
-      if(field.length || row.length){ row.push(field); rows.push(row); }
-      return rows;
-    }
-
-    /* Keyboard-safe */
-    (function setupKeyboardSafe(){
-      if (window.visualViewport) {
-        const vv = window.visualViewport;
-        const update = ()=>{
-          const kb = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
-          document.documentElement.style.setProperty('--kb', kb + 'px');
-          document.body.classList.toggle('kb-open', kb > 80);
-        };
-        vv.addEventListener('resize', update);
-        vv.addEventListener('scroll', update);
-        window.addEventListener('orientationchange', ()=> setTimeout(update, 300));
-        update();
-      }
-      const ensureVisible = (el)=>{
-        try { el.scrollIntoView({ block:'center', behavior:'smooth' }); } catch {}
-      };
-      document.addEventListener('focusin', (e)=>{
-        const el = e.target;
-        if (el.matches('input, textarea, select')) {
-          setTimeout(()=> ensureVisible(el), 250);
-        }
-      });
-    })();
-
-    async function confirmAction(message){
-      const bg = document.createElement('div'); bg.className='modal-bg flex items-center justify-center z-50';
-      const card = document.createElement('div'); card.className='modal-card bg-white rounded-2xl p-4 shadow-soft border';
-      card.innerHTML = `
-        <div class="text-sm text-gray-700 mb-3">${escapeHtml(message)}</div>
-        <div class="flex justify-end gap-2">
-          <button class="px-3 py-2 rounded-xl bg-white border">キャンセル</button>
-          <button class="px-3 py-2 rounded-xl bg-gray-900 text-white">OK</button>
-        </div>`;
-      bg.appendChild(card); document.body.appendChild(bg);
-      return new Promise(resolve=>{
-        const [btnCancel, btnOk] = card.querySelectorAll('button');
-        const cleanup = ()=> bg.remove();
-        btnCancel.onclick = ()=> { cleanup(); resolve(false); };
-        btnOk.onclick = ()=> { cleanup(); resolve(true); };
-        bg.addEventListener('click', e=> { if(e.target===bg){ cleanup(); resolve(false); } });
-      });
-    }
-    async function promptModal(message){
-      const bg = document.createElement('div'); bg.className='modal-bg flex items-center justify-center z-50';
-      const card = document.createElement('div'); card.className='modal-card bg-white rounded-2xl p-4 shadow-soft border w-[92vw] max-w-md';
-      card.innerHTML = `
-        <div class="text-sm text-gray-700 mb-2">${escapeHtml(message)}</div>
-        <input type="text" class="w-full border rounded px-3 py-2 mb-3" />
-        <div class="flex justify-end gap-2">
-          <button class="px-3 py-2 rounded-xl bg-white border">キャンセル</button>
-          <button class="px-3 py-2 rounded-xl bg-gray-900 text-white">OK</button>
-        </div>`;
-      bg.appendChild(card); document.body.appendChild(bg);
-      const [ipt] = card.getElementsByTagName('input');
-      ipt.focus();
-      return new Promise(resolve=>{
-        const [btnCancel, btnOk] = card.querySelectorAll('button');
-        const cleanup = ()=> bg.remove();
-        btnCancel.onclick = ()=> { cleanup(); resolve(null); };
-        btnOk.onclick = ()=> { const v = ipt.value.trim(); cleanup(); resolve(v||null); };
-      });
-    }
-    function bindGlobalUI(){
-      $$('.tab-btn').forEach(btn=> btn.onclick = ()=> { location.hash = btn.getAttribute('data-route'); });
-      const exportBtn = $('#btn-export-csv');
-      if(exportBtn) exportBtn.onclick = exportCSV;
-      const importInp = $('#input-import-csv');
-      if(importInp) importInp.addEventListener('change', e=> {
-        const f = e.target.files && e.target.files[0]; if(f) importCSV(f); e.target.value='';
-      });
-      const clearBtn = $('#btn-clear-data');
-      if(clearBtn) clearBtn.onclick = async ()=>{
-        if(await confirmAction('本当に全データを削除しますか？（元に戻せません）')){
-          localStorage.removeItem(K_LISTS);
-          localStorage.removeItem(K_WORKOUTS);
-          localStorage.removeItem(K_INPROG);
-          initData(); persist(); renderRoute(); afterDataChanged();
-        }
-      };
-      const chooseBtn = $('#bk-choose');
-      if(chooseBtn){ chooseBtn.onclick = ()=> alert('OPFSに自動保存します。iCloudへは「今すぐバックアップ」を使い、共有シートからFiles(iCloud Drive)に保存してください。'); }
-      const nowBtn = $('#bk-now');
-      if(nowBtn){ nowBtn.onclick = async ()=> { await backupNow(true); const c=store.get(K_BACKUPCFG, {}); const elLast=document.getElementById('bk-last'); if(elLast){ elLast.textContent = c.lastAt ? new Date(c.lastAt).toLocaleString() : '-'; } }; }
-      const restoreBtn = $('#bk-restore');
-      if(restoreBtn){ restoreBtn.onclick = async ()=> { await restoreFromFile(); }; }
-    }
-
-    (async function boot(){
-      await migrateAllIfNeeded();
-      await requestPersistence();
-      initData();
-      bindGlobalUI();
-      startAutoBackupTicker();
-      if(!location.hash) location.hash = ROUTES.HOME;
-      renderRoute();
-    })();
-  </script>
+<body class="text-gray-900 dark:text-gray-100" data-theme="auto">
+  <div id="error-bar" class="fixed top-0 left-0 right-0 z-50 hidden">
+    <div class="bg-red-600 text-white px-4 py-2 text-sm flex items-start gap-3">
+      <span class="font-semibold">Script error</span>
+      <span id="error-text" class="flex-1"></span>
+      <button id="error-close" class="underline">閉じる</button>
+    </div>
+  </div>
+  <header class="sticky top-0 z-40 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-200 dark:border-gray-700">
+    <div class="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
+      <h1 class="text-lg font-bold">筋トレ記録</h1>
+      <div class="text-xs text-gray-500">Local-only / PWA</div>
+    </div>
+  </header>
+
+  <main id="app" class="max-w-3xl mx-auto px-4 py-4 space-y-4">
+    <!-- Home -->
+    <section id="view-home" class="hidden space-y-4">
+      <div class="card">
+        <label class="text-xs text-gray-500 block">日付</label>
+        <input id="inp-date" type="date" class="w-full border rounded-lg px-3 py-2 bg-white dark:bg-gray-800">
+      </div>
+      <div class="card space-y-3">
+        <div class="grid grid-cols-2 gap-3">
+          <div class="rounded-xl border bg-white dark:bg-gray-800 p-3">
+            <div class="text-xs text-gray-500">直近1週間</div>
+            <div id="stat-week" class="text-2xl font-bold" style="color:var(--accent)">0</div>
+          </div>
+          <div class="rounded-xl border bg-white dark:bg-gray-800 p-3">
+            <div class="text-xs text-gray-500">直近1ヶ月</div>
+            <div id="stat-month" class="text-2xl font-bold" style="color:var(--accent)">0</div>
+          </div>
+        </div>
+        <div class="pt-1">
+          <button id="btn-start-or-resume" class="w-full px-4 py-3 rounded-xl text-white text-sm" style="background:var(--accent)">
+            今日のトレーニングを開始
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section id="view-workout" class="hidden">
+      <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-3">
+        <div class="flex items-center justify-between">
+          <div class="text-sm">
+            <div class="text-[11px] text-gray-500">日付</div>
+            <div id="workout-date" class="font-semibold">-</div>
+          </div>
+          <div class="text-sm">
+            <div class="text-[11px] text-gray-500">部位</div>
+            <div id="workout-part" class="font-semibold">-</div>
+          </div>
+          <div class="flex gap-2">
+            <button id="btn-back-to-home" class="px-3 py-2 rounded-xl border text-sm">戻る</button>
+            <button id="btn-save-workout" class="px-3 py-2 rounded-xl bg-gray-900 text-white text-sm">保存</button>
+          </div>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="text-sm text-gray-600">ブロック</div>
+          <div class="flex gap-2">
+            <button id="btn-add-block" class="px-3 py-2 rounded-xl border text-sm bg-white">ブロック追加</button>
+          </div>
+        </div>
+      </div>
+      <div id="blocks" class="space-y-4"></div>
+    </section>
+
+    <section id="view-history" class="hidden">
+      <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-3">
+        <div class="grid grid-cols-2 gap-2">
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500 block">開始日</label>
+            <input id="filter-start" type="date" class="w-full narrow-date border rounded-lg px-3 py-2">
+          </div>
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500 block">終了日</label>
+            <input id="filter-end" type="date" class="w-full narrow-date border rounded-lg px-3 py-2">
+          </div>
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500">部位</label>
+            <select id="filter-part" class="w-full border rounded-lg px-3 py-2"></select>
+          </div>
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500">種目名</label>
+            <select id="filter-ex" class="w-full border rounded-lg px-3 py-2"></select>
+          </div>
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500">器具</label>
+            <select id="filter-eq" class="w-full border rounded-lg px-3 py-2"></select>
+          </div>
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500">アタッチメント</label>
+            <select id="filter-att" class="w-full border rounded-lg px-3 py-2"></select>
+          </div>
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500">角度</label>
+            <select id="filter-ang" class="w-full border rounded-lg px-3 py-2"></select>
+          </div>
+          <div class="min-w-0">
+            <label class="text-xs text-gray-500">ポジション</label>
+            <select id="filter-pos" class="w-full border rounded-lg px-3 py-2"></select>
+          </div>
+        </div>
+        <div class="flex gap-2">
+          <button id="btn-apply-filter" class="px-3 py-2 rounded-xl bg-gray-900 text-white">絞り込み</button>
+          <button id="btn-clear-filter" class="px-3 py-2 rounded-xl bg-white border">クリア</button>
+        </div>
+      </div>
+
+      <div id="history-chart-wrap" class="rounded-2xl border bg-white p-3 shadow-soft mt-3 hidden">
+        <div class="flex items-center justify-between mb-2">
+          <div class="text-sm text-gray-600">1RM推移</div>
+          <button id="btn-back-to-home-from-simple" class="px-3 py-1.5 rounded-lg border hidden">入力画面に戻る</button>
+        </div>
+        <canvas id="history-chart" height="160"></canvas>
+      </div>
+
+      <div id="history-list" class="mt-3 space-y-3"></div>
+    </section>
+    <section id="view-settings" class="hidden">
+      <div class="rounded-2xl border bg-white p-3 shadow-soft space-y-4">
+        <div>
+          <div class="text-sm font-semibold mb-1">リスト編集</div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label class="text-xs text-gray-500">部位（1行1項目）</label>
+              <textarea id="list-parts" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
+            </div>
+            <div>
+              <label class="text-xs text-gray-500">器具（1行1項目）</label>
+              <textarea id="list-equip" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
+            </div>
+            <div>
+              <label class="text-xs text-gray-500">アタッチメント（1行1項目／先頭は「なし」を推奨）</label>
+              <textarea id="list-attach" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
+            </div>
+            <div>
+              <label class="text-xs text-gray-500">角度（1行1項目）</label>
+              <textarea id="list-angle" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
+            </div>
+            <div>
+              <label class="text-xs text-gray-500">ポジション（1行1項目）</label>
+              <textarea id="list-position" rows="5" class="w-full border rounded-lg px-3 py-2"></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="border-t pt-3">
+          <div class="text-sm font-semibold mb-1">種目マスタ（部位別管理）</div>
+          <p class="text-xs text-gray-500 mb-2">※ 種目名は器具名や角度名を含めない形式。表示は常にあいうえお順。削除は確認ポップアップあり。</p>
+          <div id="part-boxes" class="space-y-3"></div>
+          <div class="flex gap-2 mt-2">
+            <button id="btn-save-lists" class="px-3 py-2 rounded-xl bg-gray-900 text-white">保存</button>
+            <button id="btn-reset-defaults" class="px-3 py-2 rounded-xl bg-white border">デフォルト復元</button>
+          </div>
+        </div>
+
+        <div class="border-t pt-3">
+          <div class="text-sm font-semibold mb-1">バックアップ</div>
+          <div class="space-y-2">
+            <div class="flex items-center justify-between">
+              <label class="text-sm">自動バックアップ</label>
+              <input id="bk-auto" type="checkbox" class="w-5 h-5">
+            </div>
+            <div class="grid grid-cols-2 gap-2">
+              <div>
+                <label class="text-xs text-gray-500">頻度（分）</label>
+                <input id="bk-frequency" type="number" min="5" class="w-full border rounded px-2 py-1" />
+              </div>
+              <div class="text-xs text-gray-500 flex items-end">最終: <span id="bk-last" class="ml-1">-</span></div>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <button id="bk-choose" class="px-3 py-2 rounded-xl border">保存先を選ぶ</button>
+              <button id="bk-now" class="px-3 py-2 rounded-xl border">今すぐバックアップ</button>
+              <button id="bk-restore" class="px-3 py-2 rounded-xl border">バックアップから復元</button>
+            </div>
+            <div class="text-xs text-gray-500">iPhoneでは「今すぐバックアップ」→共有→Files（iCloud Drive）に保存で同期可能。</div>
+          </div>
+        </div>
+
+        <div class="border-t pt-3">
+          <div class="text-sm font-semibold mb-1">データ管理</div>
+          <div class="flex flex-wrap gap-2">
+            <button id="btn-export-csv" class="px-3 py-2 rounded-xl bg-white border">CSVエクスポート</button>
+            <label class="px-3 py-2 rounded-xl bg-white border cursor-pointer">
+              CSVインポート
+              <input id="input-import-csv" type="file" accept=".csv,text/csv" class="hidden">
+            </label>
+            <button id="btn-clear-data" class="px-3 py-2 rounded-xl bg-red-50 text-red-700 border border-red-200">全データ削除</button>
+          </div>
+          <p class="text-xs text-gray-500 mt-2">CSV列: date,part,exercise,equipment,attachment,angle,position,setIndex,warmup,weight,repsSelf,repsAssist,durationSec,note,oneRM</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <nav class="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900/95 backdrop-blur border-t border-gray-200 dark:border-gray-700" style="height:var(--nav-h)">
+    <div class="max-w-3xl mx-auto px-6 h-full">
+      <div class="grid grid-cols-3 h-full">
+        <button data-route="#/home" class="tab-btn flex flex-col items-center justify-center gap-0.5">
+          <span class="text-base">🏠</span><span class="text-xs">ホーム</span>
+        </button>
+        <button data-route="#/history" class="tab-btn flex flex-col items-center justify-center gap-0.5">
+          <span class="text-base">🗂️</span><span class="text-xs">履歴</span>
+        </button>
+        <button data-route="#/settings" class="tab-btn flex flex-col items-center justify-center gap-0.5">
+          <span class="text-base">⚙️</span><span class="text-xs">設定</span>
+        </button>
+      </div>
+    </div>
+  </nav>
+
+  <template id="tpl-block">
+    <div class="block-card rounded-2xl border bg-white p-3 shadow-soft space-y-3">
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="text-xs text-gray-500">ブロック</span>
+          <span class="block-index text-sm font-semibold">#1</span>
+          <span class="text-[11px] text-gray-500 block-part"></span>
+        </div>
+        <div class="flex gap-2">
+          <button class="btn-choose-ex px-2 py-1.5 rounded-lg border text-sm">種目選択/追加</button>
+          <button class="btn-del-block px-2 py-1.5 rounded-lg border border-red-200 text-red-700 text-sm">ブロック削除</button>
+        </div>
+      </div>
+      <div class="ex-config space-y-3"></div>
+      <div class="set-area space-y-2">
+        <div class="flex items-center justify-between">
+          <div class="text-sm text-gray-600">セット</div>
+          <div class="flex gap-2">
+            <button class="btn-add-set px-2 py-1.5 rounded-md bg-white border text-sm">セット追加</button>
+            <button class="btn-clear-sets px-2 py-1.5 rounded-md border text-sm">全セット削除</button>
+          </div>
+        </div>
+        <div class="set-list space-y-2"></div>
+      </div>
+    </div>
+  </template>
+
+  <template id="tpl-ex-config-row">
+    <div class="ex-config-row space-y-1">
+      <div class="text-sm font-semibold ex-name">種目名</div>
+      <div class="grid grid-cols-4 gap-1">
+        <select class="ex-eq col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
+        <select class="ex-att col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
+        <select class="ex-ang col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
+        <select class="ex-pos col-span-4 sm:col-span-1 border rounded-md px-2 py-1"></select>
+      </div>
+      <div class="text-[11px] text-gray-500 ex-meta">最高重量: - / 最高1RM: - / 前回: -</div>
+    </div>
+  </template>
+
+  <template id="tpl-set-card">
+    <div class="set-card rounded-xl border p-2 bg-gray-50 space-y-2">
+      <div class="flex items-center justify-between">
+        <div class="text-sm font-semibold">Set <span class="set-no">#1</span></div>
+        <div class="flex items-center gap-2">
+          <label class="inline-flex items-center gap-1 text-xs"><input type="checkbox" class="set-warm border rounded"> W-Up</label>
+          <button class="btn-dup-set px-2 py-1.5 rounded-md border text-xs">複製</button>
+          <button class="btn-del-set px-2 py-1.5 rounded-md border text-xs">削除</button>
+        </div>
+      </div>
+      <div class="ex-items space-y-2"></div>
+    </div>
+  </template>
+
+  <template id="tpl-ex-item-row">
+    <div class="ex-item space-y-1">
+      <div class="text-xs ex-title font-medium">種目1</div>
+      <div class="grid grid-cols-12 gap-1 items-center">
+        <input type="number" inputmode="decimal" placeholder="重量" class="ex-weight col-span-4 border rounded px-2 py-1" />
+        <input type="number" inputmode="numeric" placeholder="自力" class="ex-reps col-span-2 border rounded px-2 py-1" />
+        <input type="number" inputmode="numeric" placeholder="補助" class="ex-assist col-span-2 border rounded px-2 py-1" />
+        <div class="col-span-4 flex items-center gap-1">
+          <input type="number" inputmode="numeric" placeholder="時間(秒)" class="ex-sec flex-1 border rounded px-2 py-1" />
+          <button class="ex-sec-toggle px-2 py-1 rounded border text-xs">▶</button>
+        </div>
+        <input type="text" placeholder="メモ" class="ex-note col-span-12 border rounded px-2 py-1" />
+        <div class="col-span-12 text-[11px] text-gray-500">推定1RM: <span class="ex-1rm">-</span> kg</div>
+      </div>
+    </div>
+  </template>
+
+  <script>
+    (()=> {
+      const bar = document.getElementById('error-bar');
+      const text = document.getElementById('error-text');
+      const close = document.getElementById('error-close');
+      function show(msg){ text.textContent = String(msg||'Unknown error'); bar.classList.remove('hidden'); }
+      window.addEventListener('error', e=> show(e.message));
+      window.addEventListener('unhandledrejection', e=> show((e.reason&&e.reason.message)||e.reason));
+      close.addEventListener('click', ()=> bar.classList.add('hidden'));
+      window.__forceError = ()=> { throw new Error('Forced error'); };
+    })();
+
+    const $ = (sel, root=document)=> root.querySelector(sel);
+    const $$ = (sel, root=document)=> Array.from(root.querySelectorAll(sel));
+    const debounce = (fn, ms=300)=> { let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a), ms); }; };
+    const todayISO = ()=> new Date().toISOString().slice(0,10);
+    const toCSV = rows => rows.map(r=> r.map(v=>{
+      const s = v==null?'':String(v); return /[",\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s;
+    }).join(',')).join('\n');
+    const escapeHtml = s => String(s).replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
+    const sortJa = (arr)=> arr.slice().sort((a,b)=> String(a).localeCompare(String(b),'ja',{usage:'sort',sensitivity:'base'}));
+    const sortExerciseMapJa = (map)=> map.slice().sort((a,b)=> (a.name||'').localeCompare(b.name||'','ja',{usage:'sort',sensitivity:'base'}));
+
+    // === PATCH: routes & helpers ===
+    const ROUTES = Object.freeze({
+      HOME: '#/home',
+      WORKOUT: '#/workout',
+      HISTORY: '#/history',
+      SETTINGS: '#/settings',
+    });
+    const VIEWS = Object.freeze({
+      HOME: '#view-home',
+      WORKOUT: '#view-workout',
+      HISTORY: '#view-history',
+      SETTINGS: '#view-settings',
+    });
+
+    function orderWithNoneFirst(arr){
+      const a = Array.from(new Set(arr||[]));
+      const head = a.filter(v => v === 'なし');
+      const rest = a.filter(v => v !== 'なし')
+                    .sort((x,y)=> x.localeCompare(y,'ja',{usage:'sort',sensitivity:'base'}));
+      return [...head, ...rest];
+    }
+
+    const SCHEMA_VERSION = 8;
+    const NS = 'workout-app';
+    const K_LISTS     = NS+':lists';
+    const K_WORKOUTS  = NS+':workouts';
+    const K_INPROG    = NS+':inProgress';
+    const K_BACKUPCFG = NS+':backupConfig';
+
+    const store = {
+      getRaw(key){ try{ const raw = localStorage.getItem(key); return raw ? JSON.parse(raw) : null; }catch{ return null; } },
+      setRaw(key, obj){ localStorage.setItem(key, JSON.stringify(obj)); },
+      get(key, fallback){
+        const obj = store.getRaw(key);
+        if(!obj) return fallback;
+        return ('data' in obj) ? obj.data : obj;
+      },
+      set(key, data){ store.setRaw(key, { v: SCHEMA_VERSION, data }); },
+      getAny(key, fallback){
+        const obj = store.getRaw(key);
+        if(!obj) return fallback;
+        return ('data' in obj) ? obj.data : obj;
+      }
+    };
+
+    const DEFAULTS = {
+      parts: ['胸','背中','肩','腕','脚','腹筋'],
+      equip: ['バーベル','ダンベル','マシン','ケーブル','自重'],
+      attach: ['なし','ストレートバー','Vバー','ロープ','Dハンドル','EZバー'],
+      angle: ['なし','フラット','インクライン','デクライン','ナチュラル'],
+      position: ['なし','ナロー','ミディアム','ワイド','オーバーグリップ','アンダーグリップ','ニュートラル'],
+      exerciseMap: [
+        { name:'ベンチプレス', parts:['胸'] }, { name:'フライ', parts:['胸'] }, { name:'クロスオーバー', parts:['胸'] },
+        { name:'ペックフライ', parts:['胸'] }, { name:'プッシュアップ', parts:['胸'] }, { name:'ディップス', parts:['胸','腕'] },
+        { name:'デッドリフト', parts:['背中','脚'] }, { name:'ローイング', parts:['背中'] }, { name:'ワンハンドロー', parts:['背中'] },
+        { name:'シーテッドロー', parts:['背中'] }, { name:'ラットプルダウン', parts:['背中'] }, { name:'プルアップ', parts:['背中'] },
+        { name:'チンアップ', parts:['背中','腕'] }, { name:'フェイスプル', parts:['背中','肩'] }, { name:'ストレートアームプルダウン', parts:['背中'] },
+        { name:'ショルダープレス', parts:['肩'] }, { name:'サイドレイズ', parts:['肩'] }, { name:'フロントレイズ', parts:['肩'] },
+        { name:'リアレイズ', parts:['肩','背中'] }, { name:'アップライトロー', parts:['肩'] }, { name:'アーノルドプレス', parts:['肩'] },
+        { name:'バイセプスカール', parts:['腕'] }, { name:'ハンマーカール', parts:['腕'] }, { name:'プリーチャーカール', parts:['腕'] },
+        { name:'トライセプスエクステンション', parts:['腕'] }, { name:'オーバーヘッドトライセプスエクステンション', parts:['腕'] }, { name:'スカルクラッシャー', parts:['腕'] },
+        { name:'プレスダウン', parts:['腕'] }, { name:'クローズグリップベンチプレス', parts:['腕','胸'] },
+        { name:'スクワット', parts:['脚'] }, { name:'レッグプレス', parts:['脚'] }, { name:'ハックスクワット', parts:['脚'] },
+        { name:'ブルガリアンスクワット', parts:['脚'] }, { name:'ランジ', parts:['脚'] }, { name:'レッグエクステンション', parts:['脚'] },
+        { name:'レッグカール', parts:['脚'] }, { name:'ルーマニアンデッドリフト', parts:['脚','背中'] }, { name:'ヒップスラスト', parts:['脚'] },
+        { name:'カーフレイズ', parts:['脚'] },
+        { name:'クランチ', parts:['腹筋'] }, { name:'ハンギングレッグレイズ', parts:['腹筋'] }, { name:'ケーブルクランチ', parts:['腹筋'] },
+        { name:'プランク', parts:['腹筋'] }, { name:'アブローラー', parts:['腹筋'] }, { name:'ロシアンツイスト', parts:['腹筋'] },
+        { name:'リバースクランチ', parts:['腹筋'] }
+      ]
+    };
+
+    const state = { lists:null, workouts:null, inProgress:null, chart:null };
+
+    function cleanupExercises(map){
+      const banWords = ['ダンベル','バーベル','ケーブル','インクライン','デクライン','フラット','(ダンベル)','(バーベル)'];
+      const norm = (name)=> banWords.reduce((s,w)=> s.replaceAll(w,''), String(name)).replace(/\s+/g,'').replace(/[（）]/g,'').trim();
+      const out = []; const seen = new Set();
+      (map||[]).forEach(e=>{
+        const n = norm(e.name||'');
+        if(!n) return;
+        if(!seen.has(n)){ seen.add(n); out.push({ name:n, parts:Array.from(new Set(e.parts||[])) }); }
+        else {
+          const idx = out.findIndex(x=> x.name===n);
+          out[idx].parts = Array.from(new Set([...(out[idx].parts||[]), ...(e.parts||[])]));
+        }
+      });
+      return sortExerciseMapJa(out);
+    }
+
+    async function migrateAllIfNeeded(){
+      let lists = store.getAny(K_LISTS, null);
+      if(!lists){ lists = JSON.parse(JSON.stringify(DEFAULTS)); }
+      const uniq = a => Array.from(new Set(a||[]));
+      const putNoneFirst = a => {
+        const arr = uniq(a||[]);
+        const rest = arr.filter(x=>x!=='なし');
+        return ['なし', ...rest];
+      };
+      if(!lists.position) lists.position = DEFAULTS.position.slice();
+      lists.attach   = putNoneFirst(lists.attach || DEFAULTS.attach);
+      lists.angle    = putNoneFirst(lists.angle  || DEFAULTS.angle);
+      lists.position = putNoneFirst(lists.position);
+      lists.exerciseMap = cleanupExercises(lists.exerciseMap || DEFAULTS.exerciseMap);
+      lists.parts     = sortJa(lists.parts || DEFAULTS.parts);
+      lists.equip     = sortJa(lists.equip || DEFAULTS.equip);
+      lists.attach    = sortJa(lists.attach);
+      lists.angle     = sortJa(lists.angle);
+      lists.position  = sortJa(lists.position);
+      store.set(K_LISTS, lists);
+
+      let workouts = store.getAny(K_WORKOUTS, []);
+      workouts.forEach(w=>{
+        (w.blocks||[]).forEach(b=>{
+          if(!b.part && w.part) b.part = w.part;
+          (b.exs||[]).forEach(ex=>{
+            if(ex.pos == null) ex.pos = 'なし';
+            if(ex.att == null) ex.att = 'なし';
+            if(ex.ang == null) ex.ang = 'なし';
+          });
+          (b.sets||[]).forEach(s=>{
+            (s.items||[]).forEach(it=>{
+              if(it.sec == null) it.sec = 0;
+              if(typeof it.oneRM !== 'number') it.oneRM = 0;
+            });
+          });
+        });
+      });
+      store.set(K_WORKOUTS, workouts);
+
+      let inProg = store.getAny(K_INPROG, { date: todayISO(), part:'胸', blocks: [] });
+      if(!inProg.date) inProg.date = todayISO();
+      if(!inProg.part) inProg.part = '胸';
+      if(!Array.isArray(inProg.blocks)) inProg.blocks = [];
+      store.set(K_INPROG, inProg);
+
+      let backupCfg = store.getAny(K_BACKUPCFG, null);
+      if(!backupCfg){
+        backupCfg = { auto:true, frequencyMin:120, lastAt:null, persistGranted:false };
+        store.set(K_BACKUPCFG, backupCfg);
+      }
+    }
+
+    async function requestPersistence(){
+      if(navigator.storage && navigator.storage.persist){
+        try{
+          const granted = await navigator.storage.persist();
+          const cfg = store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false});
+          cfg.persistGranted = !!granted;
+          store.set(K_BACKUPCFG, cfg);
+        }catch{}
+      }
+    }
+
+    async function getBackupConfig(){ return store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false}); }
+    function setBackupConfig(cfg){ store.set(K_BACKUPCFG, cfg); }
+
+    function serializeAll(){
+      return JSON.stringify({
+        version: SCHEMA_VERSION,
+        exportedAt: new Date().toISOString(),
+        lists: store.get(K_LISTS, null),
+        workouts: store.get(K_WORKOUTS, []),
+        inProgress: store.get(K_INPROG, null)
+      });
+    }
+
+    async function backupNow(interactive=false){
+      const cfg = await getBackupConfig();
+      const blob = new Blob([serializeAll()], {type:'application/json'});
+      const fileName = `workout_backup_${todayISO()}.json`;
+
+      try{
+        if (navigator.storage && navigator.storage.getDirectory){
+          const root = await navigator.storage.getDirectory();
+          const handle = await root.getFileHandle('workout_backup.json', { create:true });
+          const ws = await handle.createWritable();
+          await ws.write(blob);
+          await ws.close();
+          const c = store.get(K_BACKUPCFG, cfg); c.lastAt = new Date().toISOString(); store.set(K_BACKUPCFG, c);
+        }
+      }catch(e){
+        console.error('Backup failed:', e);
+      }
+
+      if(navigator.share && interactive){
+        try{
+          const file = new File([blob], fileName, { type:'application/json' });
+          await navigator.share({ files:[file], title:'Workout Backup', text:'バックアップを保存' });
+          const c = store.get(K_BACKUPCFG, cfg); c.lastAt = new Date().toISOString(); store.set(K_BACKUPCFG, c);
+          return true;
+        }catch(e){
+          console.error('Backup failed:', e);
+        }
+      }
+
+      if(interactive){
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = fileName;
+        document.body.appendChild(a); a.click(); a.remove();
+        const c = store.get(K_BACKUPCFG, cfg); c.lastAt = new Date().toISOString(); store.set(K_BACKUPCFG, c);
+      }
+      return true;
+    }
+
+    async function restoreFromFile(){
+      try{
+        if(!window.showOpenFilePicker){ alert('このブラウザはファイル選択APIに未対応です。CSVインポートや共有からファイル取得をご利用ください。'); return; }
+        const [fileHandle] = await window.showOpenFilePicker({ types:[{description:'JSON', accept:{'application/json':['.json']}}] });
+        const file = await fileHandle.getFile();
+        const text = await file.text();
+        const obj = JSON.parse(text);
+        if(!obj.lists || !obj.workouts){ alert('不正なバックアップファイルです。'); return; }
+        store.set(K_LISTS, obj.lists);
+        store.set(K_WORKOUTS, obj.workouts);
+        if(obj.inProgress) store.set(K_INPROG, obj.inProgress);
+        alert('復元しました。再描画します。');
+        renderRoute();
+      }catch(e){
+        console.error('Restore failed:', e);
+        alert('復元に失敗しました');
+      }
+    }
+
+    let _bkTicker = null;
+    function startAutoBackupTicker(){
+      if(_bkTicker) clearInterval(_bkTicker);
+      const cfg = store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false});
+      if(!cfg.auto) return;
+      const ms = Math.max(5, Number(cfg.frequencyMin||120)) * 60 * 1000;
+      _bkTicker = setInterval(()=> backupNow(false), ms);
+    }
+
+    async function afterDataChanged(){
+      requestPersistence();
+      const cfg = await getBackupConfig();
+      if(cfg.auto){ try{ await backupNow(false); }catch{} }
+    }
+
+    function setActiveTab(hash){
+      $$('.tab-btn').forEach(btn=>{
+        const active = btn.getAttribute('data-route') === (hash.startsWith(ROUTES.WORKOUT) ? ROUTES.HOME : hash);
+        btn.classList.toggle('font-bold', active);
+      });
+    }
+    function renderRoute(){
+      const hash = location.hash || ROUTES.HOME;
+      Object.values(VIEWS).forEach(id => { const el = document.querySelector(id); if(el) el.classList.add('hidden'); });
+
+      if(hash.startsWith(ROUTES.HOME))    { document.querySelector(VIEWS.HOME).classList.remove('hidden');    renderHome(); }
+      else if(hash.startsWith(ROUTES.WORKOUT)) { document.querySelector(VIEWS.WORKOUT).classList.remove('hidden'); renderWorkout(); }
+      else if(hash.startsWith(ROUTES.HISTORY)) { document.querySelector(VIEWS.HISTORY).classList.remove('hidden'); renderHistory(); }
+      else                                  { document.querySelector(VIEWS.SETTINGS).classList.remove('hidden'); renderSettings(); }
+      setActiveTab(hash);
+    }
+    window.addEventListener('hashchange', renderRoute);
+
+    function calc1RM(weight, reps){
+      const w = Number(weight||0), r = Number(reps||0);
+      if(w<=0 || r<=0) return 0;
+      return Math.round(w * (1 + r/30) * 10) / 10;
+    }
+    function computeTrainingDays(rangeDays){
+      const cutoff = Date.now() - rangeDays*24*3600*1000;
+      const days = new Set(store.get(K_WORKOUTS, []).filter(w => new Date(w.date||todayISO()).getTime() >= cutoff).map(w => w.date||todayISO()));
+      return days.size;
+    }
+
+    function initData(){
+      state.lists = store.get(K_LISTS, JSON.parse(JSON.stringify(DEFAULTS)));
+      state.workouts = store.get(K_WORKOUTS, []);
+      state.inProgress = store.get(K_INPROG, { date: todayISO(), part: '胸', blocks: [] });
+      if(!state.inProgress.date) state.inProgress.date = todayISO();
+      if(!state.inProgress.blocks) state.inProgress.blocks = [];
+    }
+    function persist(){
+      store.set(K_LISTS, state.lists);
+      store.set(K_WORKOUTS, state.workouts);
+      store.set(K_INPROG, state.inProgress);
+    }
+
+    /* DASHBOARD */
+    function renderHome(){
+      const dateEl = $('#inp-date');
+      dateEl.value = state.inProgress.date || todayISO();
+      dateEl.onchange = (e)=> { state.inProgress.date = e.target.value || todayISO(); persist(); afterDataChanged(); };
+
+      $('#stat-week').textContent = computeTrainingDays(7);
+      $('#stat-month').textContent = computeTrainingDays(30);
+
+      $$('.part-btn').forEach(b=>{
+        const active = state.inProgress.part === b.dataset.part;
+        b.classList.toggle('bg-gray-900', active);
+        b.classList.toggle('text-white', active);
+        b.classList.toggle('bg-white', !active);
+        b.classList.toggle('text-gray-900', !active);
+        b.onclick = ()=>{ state.inProgress.part = b.dataset.part; persist(); renderHome(); };
+      });
+
+      const btn = $('#btn-start-or-resume');
+      if (btn) {
+        const hasBlocks = (state.inProgress.blocks||[]).length > 0;
+        btn.textContent = hasBlocks ? 'トレーニングを再開' : '今日のトレーニングを開始';
+        btn.onclick = ()=> { location.hash = ROUTES.WORKOUT; };
+      }
+    }
+
+    /* WORKOUT */
+    function renderWorkout(){
+      $('#workout-date').textContent = state.inProgress.date || todayISO();
+      $('#workout-part').textContent = state.inProgress.part || '-';
+      $('#btn-back-to-home').onclick = ()=> { location.hash = ROUTES.HOME; };
+      $('#btn-save-workout').onclick = ()=> { saveWorkout(); location.hash = ROUTES.HOME; };
+      $('#btn-add-block').onclick = addBlock;
+      const wrap = $('#blocks');
+      wrap.innerHTML = '';
+      (state.inProgress.blocks||[]).forEach((block, idx)=> wrap.appendChild(renderBlock(block, idx)));
+    }
+    /* Builders */
+    function renderBlock(block, idx){
+      const frag = document.importNode($('#tpl-block').content, true);
+      frag.querySelector('.block-index').textContent = '#'+(idx+1);
+      frag.querySelector('.block-part').textContent = `（${block.part || state.inProgress.part}）`;
+
+      frag.querySelector('.btn-choose-ex').onclick = ()=> openExerciseChooser(idx);
+      frag.querySelector('.btn-del-block').onclick = async ()=>{
+        if(await confirmAction('ブロックを削除しますか？')){
+          state.inProgress.blocks.splice(idx,1);
+          persist(); renderWorkout(); afterDataChanged();
+        }
+      };
+
+      const cfgWrap = frag.querySelector('.ex-config');
+      (block.exs||[]).forEach(ex=> cfgWrap.appendChild(renderExConfigRow(block, ex)));
+
+      const setWrap = frag.querySelector('.set-list');
+      frag.querySelector('.btn-add-set').onclick = ()=> { addSet(block, true); };
+      frag.querySelector('.btn-clear-sets').onclick = async ()=>{
+        if(await confirmAction('このブロックの全セットを削除しますか？')){
+          block.sets = []; persist(); renderWorkout(); afterDataChanged();
+        }
+      };
+      (block.sets||[]).forEach((set, sIdx)=> setWrap.appendChild(renderSetCard(block, set, sIdx)));
+
+      return frag;
+    }
+
+    function addBlock(){
+      state.inProgress.blocks.push({ part: state.inProgress.part, exs: [], sets: [] });
+      persist(); renderWorkout();
+      setTimeout(()=> window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' }), 0);
+      const idx = state.inProgress.blocks.length - 1;
+      setTimeout(()=> openExerciseChooser(idx), 50);
+    }
+
+    function openExerciseChooser(blockIdx){
+      const part = state.inProgress.blocks[blockIdx].part || state.inProgress.part;
+      const allowed = sortJa(state.lists.exerciseMap.filter(e=> (e.parts||[]).includes(part)).map(e=> e.name));
+      const current = new Set((state.inProgress.blocks[blockIdx].exs||[]).map(e=> e.name));
+
+      const bg = document.createElement('div'); bg.className='modal-bg flex items-center justify-center z-50';
+      const card = document.createElement('div'); card.className='modal-card bg-white rounded-2xl p-4 shadow-soft border w-[92vw]';
+      const head = document.createElement('div'); head.className='text-sm font-semibold mb-2'; head.textContent = `種目選択（${part}）`;
+      const list = document.createElement('div'); list.className='max-h-[60vh] overflow-auto space-y-1';
+
+      if(allowed.length===0){
+        const msg=document.createElement('div'); msg.className='text-sm text-gray-500';
+        msg.textContent='この部位に紐づく種目がありません。設定＞種目マスタで追加してください。';
+        list.appendChild(msg);
+      }else{
+        allowed.forEach(name=>{
+          const row=document.createElement('label'); row.className='flex items-center gap-2 text-sm';
+          const cb=document.createElement('input'); cb.type='checkbox'; cb.checked=current.has(name);
+          cb.dataset.name=name; cb.dataset.checkedAt='';
+          cb.addEventListener('change', ()=>{ cb.dataset.checkedAt = cb.checked ? String(Date.now()+Math.random()) : ''; });
+          const sp=document.createElement('span'); sp.textContent=name;
+          row.append(cb,sp); list.appendChild(row);
+        });
+      }
+
+      const actions=document.createElement('div'); actions.className='flex justify-end gap-2 mt-3';
+      const btnCancel=document.createElement('button'); btnCancel.className='px-3 py-2 rounded-xl bg-white border'; btnCancel.textContent='キャンセル';
+      const btnOk=document.createElement('button'); btnOk.className='px-3 py-2 rounded-xl bg-gray-900 text-white'; btnOk.textContent='OK';
+      actions.append(btnCancel, btnOk);
+
+      card.append(head, list, actions); bg.appendChild(card); document.body.appendChild(bg);
+      btnCancel.onclick=()=> bg.remove();
+      btnOk.onclick=()=>{
+        const cbs = Array.from(list.querySelectorAll('input[type=checkbox]:checked'));
+        // チェック順（checkedAtが無い場合はDOM順のまま）
+        cbs.sort((a,b)=>{
+          const ta=a.dataset.checkedAt, tb=b.dataset.checkedAt;
+          if(ta && tb) return ta.localeCompare(tb);
+          if(ta) return -1; if(tb) return 1; return 0;
+        });
+        const names = cbs.map(cb=> cb.dataset.name);
+        applySelectedExercises(blockIdx, names);
+        bg.remove();
+      };
+      bg.addEventListener('click', e=>{ if(e.target===bg) bg.remove(); });
+    }
+
+    function applySelectedExercises(blockIdx, names){
+      const block = state.inProgress.blocks[blockIdx];
+      const before = block.exs || [];
+
+      // 選択順のまま exs を構築（既存があれば使い回し）
+      block.exs = names.map(name => before.find(e=> e.name===name) || { name, eq: state.lists.equip[0]||'', att:'なし', ang:'なし', pos:'なし' });
+
+      // 既存セットの items も同順で並び替え/補完
+      (block.sets||[]).forEach(s=>{
+        const prevItems = s.items||[];
+        s.items = names.map(name=>{
+          const prevIdx = before.findIndex(e=> e.name===name);
+          return (prevIdx>=0 && prevItems[prevIdx]) ? prevItems[prevIdx] : { w:0, reps:0, assist:0, note:'', oneRM:0 };
+        });
+      });
+
+      // セット未作成なら1セット目を作る
+      if(!block.sets || block.sets.length===0){
+        block.sets = [{ warm:false, items: names.map(()=> ({ w:0, reps:0, assist:0, note:'', oneRM:0 })) }];
+      }
+
+      persist(); renderWorkout(); afterDataChanged && afterDataChanged();
+    }
+
+    function renderExConfigRow(block, ex){
+      const node = document.importNode($('#tpl-ex-config-row').content, true);
+      node.querySelector('.ex-name').textContent = ex.name;
+
+      // ▲/▼（テンプレに無い場合は非表示になるだけ）
+      const up = node.querySelector('.ex-move-up');
+      const down = node.querySelector('.ex-move-down');
+      if(up) up.onclick = ()=>{
+        const idx = block.exs.findIndex(e=> e===ex);
+        if(idx<=0) return;
+        [block.exs[idx-1], block.exs[idx]] = [block.exs[idx], block.exs[idx-1]];
+        (block.sets||[]).forEach(s=> [s.items[idx-1], s.items[idx]] = [s.items[idx], s.items[idx-1]]);
+        persist(); renderWorkout();
+      };
+      if(down) down.onclick = ()=>{
+        const idx = block.exs.findIndex(e=> e===ex);
+        if(idx>=block.exs.length-1) return;
+        [block.exs[idx+1], block.exs[idx]] = [block.exs[idx], block.exs[idx+1]];
+        (block.sets||[]).forEach(s=> [s.items[idx+1], s.items[idx]] = [s.items[idx], s.items[idx+1]]);
+        persist(); renderWorkout();
+      };
+
+      // 「なし」を先頭固定で描画
+      const fill = (sel, arr, val, cb)=>{
+        sel.innerHTML=''; orderWithNoneFirst(arr).forEach(v=> {
+          const o=document.createElement('option'); o.value=v; o.textContent=v; sel.appendChild(o);
+        });
+        sel.value = val || 'なし';
+        sel.onchange = e=> cb(e.target.value);
+      };
+      fill(node.querySelector('.ex-eq'),  state.lists.equip,    ex.eq || state.lists.equip[0], v=>{ ex.eq=v; persist(); });
+      fill(node.querySelector('.ex-att'), state.lists.attach,   ex.att || 'なし',               v=>{ ex.att=v; persist(); });
+      fill(node.querySelector('.ex-ang'), state.lists.angle,    ex.ang || 'なし',               v=>{ ex.ang=v; persist(); });
+      fill(node.querySelector('.ex-pos'), state.lists.position, ex.pos || 'なし',               v=>{ ex.pos=v; persist(); });
+
+      updateExMetaLine(node, ex);
+      return node;
+    }
+
+    function updateExMetaLine(rowNode, ex){
+      const meta = rowNode.querySelector('.ex-meta');
+      const all = flattenSets().filter(r=> r.exercise===ex.name);
+      if(all.length===0){ meta.textContent='最高重量: - / 最高1RM: - / 前回: -'; return; }
+      const maxW = Math.max(...all.map(r=> Number(r.weight||0)));
+      const max1 = Math.max(...all.map(r=> Number(r.oneRM||0)));
+      const last = all.sort((a,b)=> a.date<b.date ? 1 : -1)[0];
+      meta.textContent = `最高重量: ${maxW||'-'} / 最高1RM: ${max1||'-'} / 前回: ${last ? last.date : '-'}`;
+    }
+
+    function renderSetCard(block, set, sIdx){
+      const node = document.importNode($('#tpl-set-card').content, true);
+      node.querySelector('.set-no').textContent = '#'+(sIdx+1);
+      const warm = node.querySelector('.set-warm');
+      warm.checked = !!set.warm;
+      warm.addEventListener('input', ()=> { set.warm = warm.checked; persist(); afterDataChanged(); });
+
+      const itemsWrap = node.querySelector('.ex-items');
+      ensureSetItems(block, set);
+      (block.exs||[]).forEach((ex, i)=> itemsWrap.appendChild(renderExItemRow(block, set, i, ex)));
+
+      node.querySelector('.btn-dup-set').onclick = ()=> {
+        const source = block.sets[sIdx];
+        const cloned = JSON.parse(JSON.stringify(source));
+        block.sets.splice(sIdx+1, 0, cloned);
+        persist(); renderWorkout(); afterDataChanged();
+      };
+      node.querySelector('.btn-del-set').onclick = ()=> {
+        block.sets.splice(sIdx,1);
+        persist(); renderWorkout(); afterDataChanged();
+      };
+      return node;
+    }
+
+    function ensureSetItems(block, set){
+      if(!set.items) set.items = [];
+      const need = (block.exs||[]).length;
+      if(set.items.length < need){
+        const last = set.items[set.items.length-1] || { w:0, reps:0, assist:0, note:'', oneRM:0, sec:0 };
+        for(let i=set.items.length; i<need; i++){ set.items[i] = { ...last }; }
+      } else if(set.items.length > need){
+        set.items = set.items.slice(0, need);
+      }
+    }
+
+    function addSet(block, copyLast){
+      if(!block.sets) block.sets = [];
+      if(copyLast && block.sets.length){
+        const last = block.sets[block.sets.length-1];
+        const cloned = JSON.parse(JSON.stringify(last));
+        block.sets.push(cloned);
+      } else {
+        const items = (block.exs||[]).map(()=> ({ w:0, reps:0, assist:0, note:'', oneRM:0, sec:0 }));
+        block.sets.push({ warm:false, items });
+      }
+      persist(); renderWorkout(); afterDataChanged();
+      setTimeout(()=> window.scrollTo({ top: document.body.scrollHeight, behavior:'smooth' }), 0);
+    }
+
+    function renderExItemRow(block, set, idx, ex){
+      const node = document.importNode($('#tpl-ex-item-row').content, true);
+      const item = set.items[idx] ||= { w:0, reps:0, assist:0, note:'', oneRM:0, sec:0 };
+
+      // 見出し：実際の種目名
+      const titleEl = node.querySelector('.ex-title');
+      if(titleEl) titleEl.textContent = ex.name;
+
+      // 入力
+      const elW = node.querySelector('.ex-weight');
+      const elR = node.querySelector('.ex-reps');
+      const elA = node.querySelector('.ex-assist');
+      const elN = node.querySelector('.ex-note');
+      const elOne = node.querySelector('.ex-1rm');
+      const elSec = node.querySelector('.ex-sec'); // 秒入力は残す（手入力用）
+
+      elW.value = item.w || '';
+      elR.value = item.reps || '';
+      elA.value = item.assist || '';
+      elN.value = item.note || '';
+      if(elSec) elSec.value = item.sec || '';
+
+      const recalc = debounce(()=>{
+        const w = Number(elW.value||0), r = Number(elR.value||0);
+        item.w = w; item.reps = r; item.assist = Number(elA.value||0); item.note = elN.value || '';
+        if(elSec){ item.sec = Number(elSec.value||0); }
+        item.oneRM = (w>0 && r>0) ? Math.round(w * (1 + r/30) * 10)/10 : 0;
+        elOne.textContent = item.oneRM || '-';
+        persist();
+      }, 120);
+
+      [elW, elR, elA, elN].forEach(el => el && el.addEventListener('input', recalc));
+      if(elSec) elSec.addEventListener('input', recalc);
+
+      // タイマーボタン（▶/■）は廃止：テンプレに残っていても何もしない
+      const toggle = node.querySelector('.ex-sec-toggle');
+      if(toggle) toggle.remove();
+
+      elOne.textContent = item.oneRM || '-';
+      return node;
+    }
+
+    /* Save workout & history */
+    function saveWorkout(){
+      const copy = JSON.parse(JSON.stringify(state.inProgress));
+      copy.blocks.forEach(b=>{
+        b.sets = (b.sets||[]).map(s=>{
+          s.items = (s.items||[]).filter(it=>{
+            return (Number(it.sec)>0) || (Number(it.w)>0 && Number(it.reps)>0) || it.note;
+          });
+          return s;
+        }).filter(s=> s.items.length>0);
+      });
+      copy.blocks = copy.blocks.filter(b=> (b.exs||[]).length>0 && (b.sets||[]).length>0);
+      if(copy.blocks.length===0){ alert('記録が空です。セットを入力してください。'); return; }
+      copy.id = 'w_'+Date.now();
+      state.workouts.push(copy);
+      state.inProgress = { date: state.inProgress.date || todayISO(), part: state.inProgress.part, blocks: [] };
+      persist(); alert('保存しました'); afterDataChanged();
+    }
+
+    function flattenSets(){
+      const rows = [];
+      (store.get(K_WORKOUTS, [])).forEach(w=>{
+        (w.blocks||[]).forEach(b=>{
+          (b.sets||[]).forEach((s, sIdx)=>{
+            (b.exs||[]).forEach((ex, exIdx)=>{
+              const it = (s.items||[])[exIdx] || {};
+              rows.push({
+                id: w.id, date: w.date || state.inProgress.date || todayISO(), part: b.part || '不明',
+                exercise: ex.name, equipment: ex.eq||'', attachment: ex.att||'なし',
+                angle: ex.ang||'なし', position: ex.pos||'なし', setIndex: sIdx+1,
+                warmup: !!s.warm, weight: Number(it.w||0), repsSelf: Number(it.reps||0),
+                repsAssist: Number(it.assist||0), durationSec: Number(it.sec||0), note: it.note||'',
+                oneRM: Number(it.oneRM||0)
+              });
+            });
+          });
+        });
+      });
+      return rows.sort((a,b)=> a.date<b.date ? -1 : 1);
+    }
+
+    function renderHistory(){
+      const parts = ['(指定なし)', ...sortJa(state.lists.parts)];
+      const exs   = ['(指定なし)', ...sortJa(Array.from(new Set(flattenSets().map(r=> r.exercise))))];
+      const eqs   = ['(指定なし)', ...sortJa(state.lists.equip)];
+      const atts  = ['(指定なし)', ...orderWithNoneFirst(state.lists.attach)];
+      const angs  = ['(指定なし)', ...orderWithNoneFirst(state.lists.angle)];
+      const poss  = ['(指定なし)', ...orderWithNoneFirst(state.lists.position)];
+      const fillSel=(id,arr)=>{ const el=$(id); if(!el) return; el.innerHTML=''; arr.forEach(v=>{ const o=document.createElement('option'); o.value=v;o.textContent=v; el.appendChild(o); }); };
+      fillSel('#filter-part',parts); fillSel('#filter-ex',exs); fillSel('#filter-eq',eqs);
+      fillSel('#filter-att',atts);   fillSel('#filter-ang',angs); fillSel('#filter-pos',poss);
+
+      $('#btn-apply-filter').onclick = ()=> applyFilter();
+      $('#btn-clear-filter').onclick = ()=> {
+        $('#filter-start').value=''; $('#filter-end').value='';
+        ['part','ex','eq','att','ang','pos'].forEach(id=> $('#filter-'+id).value='(指定なし)');
+        applyFilter();
+      };
+
+      const params = new URLSearchParams(location.hash.split('?')[1] || '');
+      const exParam = params.get('exercise');
+      if(exParam){ $('#filter-ex').value = exParam; }
+      applyFilter();
+    }
+
+    function applyFilter(){
+      const start = $('#filter-start').value;
+      const end = $('#filter-end').value;
+      const part = $('#filter-part').value;
+      const ex = $('#filter-ex').value;
+      const eq = $('#filter-eq').value;
+      const att = $('#filter-att').value;
+      const ang = $('#filter-ang').value;
+      const pos = $('#filter-pos').value;
+
+      let rows = flattenSets();
+      if(start) rows = rows.filter(r => r.date >= start);
+      if(end) rows = rows.filter(r => r.date <= end);
+      if(part && part!=='(指定なし)') rows = rows.filter(r => r.part===part);
+      if(ex && ex!=='(指定なし)') rows = rows.filter(r => r.exercise===ex);
+      if(eq && eq!=='(指定なし)') rows = rows.filter(r => r.equipment===eq);
+      if(att && att!=='(指定なし)') rows = rows.filter(r => r.attachment===att);
+      if(ang && ang!=='(指定なし)') rows = rows.filter(r => r.angle===ang);
+      if(pos && pos!=='(指定なし)') rows = rows.filter(r => r.position===pos);
+
+      renderHistoryList(rows);
+      if(ex && ex!=='(指定なし)'){
+        const dailyMax = aggregateDailyMax1RM(rows);
+        renderChart(dailyMax.labels, dailyMax.values, true);
+      } else { renderChart([], [], false); }
+    }
+
+    function aggregateDailyMax1RM(rows){
+      const map = new Map();
+      rows.forEach(r=>{
+        const key = r.date;
+        const prev = map.get(key) || 0;
+        map.set(key, Math.max(prev, r.oneRM||0));
+      });
+      const labels = Array.from(map.keys()).sort();
+      const values = labels.map(d => map.get(d));
+      return { labels, values };
+    }
+
+    function renderHistoryList(rows){
+      const list = $('#history-list');
+      list.innerHTML = '';
+      if(rows.length===0){ list.innerHTML = '<div class="text-sm text-gray-500">データがありません。</div>'; return; }
+
+      const byWorkout = rows.reduce((acc, r)=> { (acc[r.id] ||= []).push(r); return acc; }, {});
+      Object.values(byWorkout).forEach(items=>{
+        const w = items[0];
+        const card = document.createElement('div');
+        card.className = 'rounded-2xl border bg-white p-3 shadow-soft';
+        const partsInWorkout = Array.from(new Set(items.map(i=>i.part))).join(' / ');
+        const title = document.createElement('div');
+        title.className = 'flex items-center justify-between';
+        title.innerHTML = `<div class="text-sm font-semibold">${w.date} / ${partsInWorkout}</div>`;
+        card.appendChild(title);
+        items.forEach(r=>{
+          const timeLabel = r.durationSec ? ` / 時間 ${r.durationSec}s` : '';
+          const row = document.createElement('div');
+          row.className = 'mt-2 text-sm grid grid-cols-12 gap-1';
+          row.innerHTML = `
+            <div class="col-span-6 truncate-2">${r.exercise} <span class="text-xs text-gray-500">(${r.equipment} / ${r.attachment} / ${r.angle} / ${r.position})</span></div>
+            <div class="col-span-3">重量 ${r.weight}kg</div>
+            <div class="col-span-1">自 ${r.repsSelf}</div>
+            <div class="col-span-2">補 ${r.repsAssist}</div>
+            <div class="col-span-12 text-[11px] text-gray-500">部位:${r.part}${timeLabel} / 1RM:${r.oneRM || '-'}kg / S${r.setIndex} ${r.note ? ' / '+escapeHtml(r.note) : ''}</div>
+          `;
+          card.appendChild(row);
+        });
+        list.appendChild(card);
+      });
+
+      const params = new URLSearchParams(location.hash.split('?')[1] || '');
+      const exParam = params.get('exercise');
+      const backBtn = $('#btn-back-to-home-from-simple');
+      if(backBtn){ backBtn.classList.toggle('hidden', !exParam); backBtn.onclick = ()=> { location.hash = '#/workout'; }; }
+    }
+
+    function renderChart(labels, values, show){
+      const wrap = $('#history-chart-wrap');
+      wrap.classList.toggle('hidden', !show);
+      if(!show){ if(state.chart){ state.chart.destroy(); state.chart=null; } return; }
+      const ctx = $('#history-chart').getContext('2d');
+      if(state.chart) state.chart.destroy();
+      state.chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels, datasets: [{ label: '1RM (kg)', data: values, tension: 0.25, pointRadius: 3 }] },
+        options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
+      });
+    }
+
+    /* SETTINGS */
+    function renderSettings(){
+      $('#list-parts').value = sortJa(state.lists.parts).join('\n');
+      $('#list-equip').value = sortJa(state.lists.equip).join('\n');
+      $('#list-attach').value = sortJa(state.lists.attach).join('\n');
+      $('#list-angle').value = sortJa(state.lists.angle).join('\n');
+      $('#list-position').value = sortJa(state.lists.position).join('\n');
+
+      const boxes = $('#part-boxes');
+      boxes.innerHTML = '';
+      const parts = sortJa(state.lists.parts);
+
+      parts.forEach(part=>{
+        const card = document.createElement('div');
+        card.className = 'rounded-xl border p-3 bg-white shadow-soft';
+        const head = document.createElement('div');
+        head.className = 'flex items-center justify-between mb-2';
+        head.innerHTML = `<div class="text-sm font-semibold">${part} の種目</div>`;
+        const addBtn = document.createElement('button');
+        addBtn.className = 'px-2 py-1.5 rounded-md border text-xs';
+        addBtn.textContent = '追加';
+        head.appendChild(addBtn);
+        card.appendChild(head);
+
+        const list = document.createElement('div');
+        list.className = 'space-y-1';
+        card.appendChild(list);
+
+        function refreshList(){
+          list.innerHTML = '';
+          const rows = sortExerciseMapJa(state.lists.exerciseMap).filter(e=> (e.parts||[]).includes(part));
+          if(rows.length===0){
+            list.innerHTML = `<div class="text-xs text-gray-500">まだありません。</div>`;
+          }else{
+            rows.forEach(row=> list.appendChild(renderExerciseRowByPart(row, part, refreshList)));
+          }
+        }
+
+        addBtn.onclick = async ()=>{
+          const name = await promptModal('新しい種目名を入力（器具名・角度名は含めない）');
+          if(!name) return;
+          const clean = cleanupExercises([{name, parts:[part]}])[0];
+          if(!clean) return;
+          const idx = state.lists.exerciseMap.findIndex(e=> e.name===clean.name);
+          if(idx>=0){
+            const pset = new Set(state.lists.exerciseMap[idx].parts||[]);
+            pset.add(part);
+            state.lists.exerciseMap[idx].parts = Array.from(pset);
+          }else{
+            state.lists.exerciseMap.push({ name: clean.name, parts:[part] });
+          }
+          state.lists.exerciseMap = sortExerciseMapJa(state.lists.exerciseMap);
+          persist(); refreshList(); afterDataChanged();
+        };
+
+        refreshList();
+        boxes.appendChild(card);
+      });
+
+      $('#btn-save-lists').onclick = ()=> { saveLists(); };
+      $('#btn-reset-defaults').onclick = ()=> { resetDefaults(); };
+
+      const cfg = store.get(K_BACKUPCFG, {auto:true,frequencyMin:120,lastAt:null,persistGranted:false});
+      const elAuto = document.getElementById('bk-auto');
+      const elFreq = document.getElementById('bk-frequency');
+      const elLast = document.getElementById('bk-last');
+      if(elAuto){ elAuto.checked = !!cfg.auto; elAuto.onchange = ()=> { const c=store.get(K_BACKUPCFG,cfg); c.auto = elAuto.checked; store.set(K_BACKUPCFG,c); startAutoBackupTicker(); }; }
+      if(elFreq){ elFreq.value = cfg.frequencyMin || 120; elFreq.oninput = ()=> { const c=store.get(K_BACKUPCFG,cfg); c.frequencyMin = Math.max(5, Number(elFreq.value||120)); store.set(K_BACKUPCFG,c); startAutoBackupTicker(); }; }
+      if(elLast){ elLast.textContent = cfg.lastAt ? new Date(cfg.lastAt).toLocaleString() : '-'; }
+      const chooseBtn = document.getElementById('bk-choose');
+      if(chooseBtn){ chooseBtn.onclick = ()=> alert('OPFSに自動保存します。iCloudへは「今すぐバックアップ」を使い、共有シートからFiles(iCloud Drive)に保存してください。'); }
+      const nowBtn = document.getElementById('bk-now');
+      if(nowBtn){ nowBtn.onclick = async ()=> { await backupNow(true); const c=store.get(K_BACKUPCFG, {}); const elLast=document.getElementById('bk-last'); if(elLast){ elLast.textContent = c.lastAt ? new Date(c.lastAt).toLocaleString() : '-'; } }; }
+      const restoreBtn = document.getElementById('bk-restore');
+      if(restoreBtn){ restoreBtn.onclick = async ()=> { await restoreFromFile(); }; }
+    }
+
+    function renderExerciseRowByPart(row, part, refresh){
+      const wrap = document.createElement('div');
+      wrap.className = 'grid grid-cols-12 gap-1 items-center';
+      const nameCol = document.createElement('div');
+      nameCol.className = 'col-span-7';
+      const ipt = document.createElement('input');
+      ipt.type = 'text';
+      ipt.className = 'w-full border rounded px-2 py-1 text-sm';
+      ipt.value = row.name;
+      nameCol.appendChild(ipt);
+
+      const btns = document.createElement('div');
+      btns.className = 'col-span-5 flex justify-end gap-2';
+      const btnSave = document.createElement('button');
+      btnSave.className = 'px-2 py-1.5 rounded-md border text-xs';
+      btnSave.textContent = '名称更新';
+      const btnDel = document.createElement('button');
+      btnDel.className = 'px-2 py-1.5 rounded-md border text-xs text-red-700 border-red-200';
+      btnDel.textContent = '削除';
+
+      btns.appendChild(btnSave);
+      btns.appendChild(btnDel);
+
+      btnSave.onclick = ()=>{
+        const newNameRaw = ipt.value.trim();
+        if(!newNameRaw) return;
+        const cleaned = cleanupExercises([{name:newNameRaw, parts:row.parts}])[0];
+        if(!cleaned) return;
+        const idxOther = state.lists.exerciseMap.findIndex(e=> e.name===cleaned.name);
+        const idxSelf  = state.lists.exerciseMap.findIndex(e=> e.name===row.name);
+        if(idxOther>=0 && idxOther!==idxSelf){
+          const merged = Array.from(new Set([...(state.lists.exerciseMap[idxOther].parts||[]), ...(state.lists.exerciseMap[idxSelf].parts||[])]));
+          state.lists.exerciseMap[idxOther].parts = merged;
+          state.lists.exerciseMap.splice(idxSelf,1);
+        }else{
+          state.lists.exerciseMap[idxSelf].name = cleaned.name;
+        }
+        state.lists.exerciseMap = sortExerciseMapJa(state.lists.exerciseMap);
+        persist(); refresh(); afterDataChanged();
+      };
+
+      btnDel.onclick = async ()=>{
+        const ok = await confirmAction(`「${row.name}」を${part}から削除します。よろしいですか？（他の部位に属していない場合は種目自体が削除されます）`);
+        if(!ok) return;
+        const idx = state.lists.exerciseMap.findIndex(e=> e.name===row.name);
+        if(idx<0) return;
+        const p = new Set(state.lists.exerciseMap[idx].parts||[]);
+        p.delete(part);
+        const newParts = Array.from(p);
+        if(newParts.length===0){
+          const ok2 = await confirmAction(`「${row.name}」はどの部位にも属さなくなります。種目自体を削除します。よろしいですか？`);
+          if(!ok2) return;
+          state.lists.exerciseMap.splice(idx,1);
+        }else{
+          state.lists.exerciseMap[idx].parts = newParts;
+        }
+        persist(); refresh(); afterDataChanged();
+      };
+
+      wrap.appendChild(nameCol);
+      wrap.appendChild(btns);
+      return wrap;
+    }
+
+    function saveLists(){
+      const parseLines = v => v.split('\n').map(s=>s.trim()).filter(Boolean);
+      state.lists.parts = sortJa(parseLines($('#list-parts').value));
+      state.lists.equip = sortJa(parseLines($('#list-equip').value));
+      state.lists.attach = sortJa(parseLines($('#list-attach').value));
+      if(state.lists.attach[0] !== 'なし'){ state.lists.attach = ['なし', ...state.lists.attach.filter(x=>x!=='なし')]; }
+      state.lists.angle = sortJa(parseLines($('#list-angle').value));
+      if(state.lists.angle[0] !== 'なし'){ state.lists.angle = ['なし', ...state.lists.angle.filter(x=>x!=='なし')]; }
+      state.lists.position = sortJa(parseLines($('#list-position').value));
+      if(state.lists.position[0] !== 'なし'){ state.lists.position = ['なし', ...state.lists.position.filter(x=>x!=='なし')]; }
+
+      state.lists.exerciseMap = cleanupExercises(sortExerciseMapJa(
+        state.lists.exerciseMap.filter(r=> (r.name && r.name.trim().length>0))
+      ));
+
+      persist();
+      alert('保存しました');
+      if(location.hash.startsWith(ROUTES.HOME)) renderHome();
+      afterDataChanged();
+    }
+
+    function resetDefaults(){
+      state.lists = JSON.parse(JSON.stringify(DEFAULTS));
+      state.lists.parts = sortJa(state.lists.parts);
+      state.lists.equip = sortJa(state.lists.equip);
+      state.lists.attach = sortJa(state.lists.attach);
+      state.lists.angle = sortJa(state.lists.angle);
+      state.lists.position = sortJa(state.lists.position);
+      state.lists.exerciseMap = cleanupExercises(sortExerciseMapJa(state.lists.exerciseMap));
+      persist(); renderSettings(); alert('デフォルトに復元しました'); afterDataChanged();
+    }
+
+    function exportCSV(){
+      const rows = flattenSets().map(r=>[
+        r.date, r.part, r.exercise, r.equipment, r.attachment, r.angle, r.position,
+        r.setIndex, r.warmup ? 1 : 0, r.weight, r.repsSelf, r.repsAssist, r.durationSec, r.note, r.oneRM
+      ]);
+      rows.unshift(['date','part','exercise','equipment','attachment','angle','position','setIndex','warmup','weight','repsSelf','repsAssist','durationSec','note','oneRM']);
+      const blob = new Blob([toCSV(rows)], {type:'text/csv;charset=utf-8;'});
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `workouts_${todayISO()}.csv`;
+      document.body.appendChild(a); a.click(); a.remove();
+    }
+
+    function importCSV(file){
+      const reader = new FileReader();
+      reader.onload = ()=>{
+        const text = reader.result;
+        const rows = parseCSV(text);
+        const header = rows.shift() || [];
+        const idx = name => header.indexOf(name);
+        const dateI=idx('date'), partI=idx('part'), exI=idx('exercise'), eqI=idx('equipment'), attI=idx('attachment'), angI=idx('angle'), posI=idx('position'),
+              sI=idx('setIndex'), warmI=idx('warmup'), wI=idx('weight'), rsI=idx('repsSelf'), raI=idx('repsAssist'), durI=idx('durationSec'), noteI=idx('note'), oneI=idx('oneRM');
+        if(dateI<0 || partI<0 || exI<0){ alert('CSVヘッダが不正です'); return; }
+
+        const groups = {};
+        rows.forEach(r=>{
+          const date = r[dateI]; if(!date) return;
+          const part = r[partI] || '不明';
+          const key = date+'|'+part;
+          (groups[key] ||= []).push({
+            exercise: r[exI]||'', equipment: r[eqI]||'', attachment: r[attI]||'なし',
+            angle: r[angI]||'なし', position: r[posI]||'なし', setIndex: Number(r[sI]||1),
+            warmup: Number(r[warmI]||0)>0, weight: Number(r[wI]||0), repsSelf: Number(r[rsI]||0),
+            repsAssist: Number(r[raI]||0), durationSec: Number(r[durI]||0), note: r[noteI]||'',
+            oneRM: Number(r[oneI]||0)
+          });
+        });
+
+        Object.entries(groups).forEach(([key, items])=>{
+          const [date, part] = key.split('|');
+          const exNames = Array.from(new Set(items.map(it=> it.exercise)));
+          const maxSet = Math.max(0, ...items.map(it=> it.setIndex||0));
+          const exs = exNames.map(name=>{
+            const any = items.find(it=> it.exercise===name) || {};
+            const cleanedName = cleanupExercises([{name, parts:[]}])[0]?.name || name;
+            return { name: cleanedName, eq:any.equipment||'', att:any.attachment||'なし', ang:any.angle||'なし', pos:any.position||'なし' };
+          });
+          const sets = [];
+          for(let s=1; s<=Math.max(1, maxSet); s++){
+            const set = { warm:false, items: exNames.map(()=> ({ w:0,reps:0,assist:0,sec:0,note:'',oneRM:0 })) };
+            exNames.forEach((name, i)=>{
+              const it = items.find(it=> it.exercise===name && it.setIndex===s);
+              if(it){
+                set.warm = set.warm || !!it.warmup;
+                set.items[i] = { w:it.weight, reps:it.repsSelf, assist:it.repsAssist, sec:it.durationSec||0, note:it.note, oneRM: it.durationSec>0?0:(it.oneRM||calc1RM(it.weight,it.repsSelf)) };
+              }
+            });
+            sets.push(set);
+          }
+          state.workouts.push({ id:'w_'+Date.now()+Math.random(), date, blocks:[{ part, exs, sets }] });
+        });
+
+        persist(); alert('インポート完了'); if(location.hash.startsWith(ROUTES.HISTORY)) renderHistory(); afterDataChanged();
+      };
+      reader.readAsText(file);
+    }
+
+    function parseCSV(text){
+      const rows = []; let i=0, field='', row=[], inQ=false;
+      while(i<text.length){
+        const c=text[i++];
+        if(inQ){ if(c=== '"'){ if(text[i]==='"'){ field+='"'; i++; } else { inQ=false; } } else { field+=c; } }
+        else { if(c===','){ row.push(field); field=''; } else if(c==='"'){ inQ=true; } else if(c==='\n'){ row.push(field); rows.push(row); row=[]; field=''; } else if(c!=='\r'){ field+=c; } }
+      }
+      if(field.length || row.length){ row.push(field); rows.push(row); }
+      return rows;
+    }
+
+    /* Keyboard-safe */
+    (function setupKeyboardSafe(){
+      if (window.visualViewport) {
+        const vv = window.visualViewport;
+        const update = ()=>{
+          const kb = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+          document.documentElement.style.setProperty('--kb', kb + 'px');
+          document.body.classList.toggle('kb-open', kb > 80);
+        };
+        vv.addEventListener('resize', update);
+        vv.addEventListener('scroll', update);
+        window.addEventListener('orientationchange', ()=> setTimeout(update, 300));
+        update();
+      }
+      const ensureVisible = (el)=>{
+        try { el.scrollIntoView({ block:'center', behavior:'smooth' }); } catch {}
+      };
+      document.addEventListener('focusin', (e)=>{
+        const el = e.target;
+        if (el.matches('input, textarea, select')) {
+          setTimeout(()=> ensureVisible(el), 250);
+        }
+      });
+    })();
+
+    async function confirmAction(message){
+      const bg = document.createElement('div'); bg.className='modal-bg flex items-center justify-center z-50';
+      const card = document.createElement('div'); card.className='modal-card bg-white rounded-2xl p-4 shadow-soft border';
+      card.innerHTML = `
+        <div class="text-sm text-gray-700 mb-3">${escapeHtml(message)}</div>
+        <div class="flex justify-end gap-2">
+          <button class="px-3 py-2 rounded-xl bg-white border">キャンセル</button>
+          <button class="px-3 py-2 rounded-xl bg-gray-900 text-white">OK</button>
+        </div>`;
+      bg.appendChild(card); document.body.appendChild(bg);
+      return new Promise(resolve=>{
+        const [btnCancel, btnOk] = card.querySelectorAll('button');
+        const cleanup = ()=> bg.remove();
+        btnCancel.onclick = ()=> { cleanup(); resolve(false); };
+        btnOk.onclick = ()=> { cleanup(); resolve(true); };
+        bg.addEventListener('click', e=> { if(e.target===bg){ cleanup(); resolve(false); } });
+      });
+    }
+    async function promptModal(message){
+      const bg = document.createElement('div'); bg.className='modal-bg flex items-center justify-center z-50';
+      const card = document.createElement('div'); card.className='modal-card bg-white rounded-2xl p-4 shadow-soft border w-[92vw] max-w-md';
+      card.innerHTML = `
+        <div class="text-sm text-gray-700 mb-2">${escapeHtml(message)}</div>
+        <input type="text" class="w-full border rounded px-3 py-2 mb-3" />
+        <div class="flex justify-end gap-2">
+          <button class="px-3 py-2 rounded-xl bg-white border">キャンセル</button>
+          <button class="px-3 py-2 rounded-xl bg-gray-900 text-white">OK</button>
+        </div>`;
+      bg.appendChild(card); document.body.appendChild(bg);
+      const [ipt] = card.getElementsByTagName('input');
+      ipt.focus();
+      return new Promise(resolve=>{
+        const [btnCancel, btnOk] = card.querySelectorAll('button');
+        const cleanup = ()=> bg.remove();
+        btnCancel.onclick = ()=> { cleanup(); resolve(null); };
+        btnOk.onclick = ()=> { const v = ipt.value.trim(); cleanup(); resolve(v||null); };
+      });
+    }
+    function bindGlobalUI(){
+      $$('.tab-btn').forEach(btn=> btn.onclick = ()=> { location.hash = btn.getAttribute('data-route'); });
+      const exportBtn = $('#btn-export-csv');
+      if(exportBtn) exportBtn.onclick = exportCSV;
+      const importInp = $('#input-import-csv');
+      if(importInp) importInp.addEventListener('change', e=> {
+        const f = e.target.files && e.target.files[0]; if(f) importCSV(f); e.target.value='';
+      });
+      const clearBtn = $('#btn-clear-data');
+      if(clearBtn) clearBtn.onclick = async ()=>{
+        if(await confirmAction('本当に全データを削除しますか？（元に戻せません）')){
+          localStorage.removeItem(K_LISTS);
+          localStorage.removeItem(K_WORKOUTS);
+          localStorage.removeItem(K_INPROG);
+          initData(); persist(); renderRoute(); afterDataChanged();
+        }
+      };
+      const chooseBtn = $('#bk-choose');
+      if(chooseBtn){ chooseBtn.onclick = ()=> alert('OPFSに自動保存します。iCloudへは「今すぐバックアップ」を使い、共有シートからFiles(iCloud Drive)に保存してください。'); }
+      const nowBtn = $('#bk-now');
+      if(nowBtn){ nowBtn.onclick = async ()=> { await backupNow(true); const c=store.get(K_BACKUPCFG, {}); const elLast=document.getElementById('bk-last'); if(elLast){ elLast.textContent = c.lastAt ? new Date(c.lastAt).toLocaleString() : '-'; } }; }
+      const restoreBtn = $('#bk-restore');
+      if(restoreBtn){ restoreBtn.onclick = async ()=> { await restoreFromFile(); }; }
+    }
+
+    (async function boot(){
+      await migrateAllIfNeeded();
+      await requestPersistence();
+      initData();
+      bindGlobalUI();
+      startAutoBackupTicker();
+      if(!location.hash) location.hash = ROUTES.HOME;
+      renderRoute();
+    })();
+  </script>
 </body>
 </html>
-```


### PR DESCRIPTION
## Summary
- rebuild the root HTML with a refreshed Tailwind configuration, theme tokens, and dark-mode support
- rework the home, workout, history, and settings layouts using card-based sections, templates, and a persistent bottom navigation
- overhaul the client-side script to manage routes, exercises, sets, filtering, backups, CSV import/export, and other utilities

## Testing
- npm test -- --watch=false *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68da330e002483338b18665b73b9a298