### PR TITLE
Add body part selector to home view

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,10 @@
             <div id="stat-month" class="text-2xl font-bold" style="color:var(--accent)">0</div>
           </div>
         </div>
+        <div>
+          <div class="text-xs text-gray-500 mb-2">部位</div>
+          <div id="part-buttons" class="flex flex-wrap gap-2"></div>
+        </div>
         <div class="pt-1">
           <button id="btn-start-or-resume" class="w-full px-4 py-3 rounded-xl text-white text-sm" style="background:var(--accent)">
             今日のトレーニングを開始
@@ -632,14 +636,43 @@
       $('#stat-week').textContent = computeTrainingDays(7);
       $('#stat-month').textContent = computeTrainingDays(30);
 
-      $$('.part-btn').forEach(b=>{
-        const active = state.inProgress.part === b.dataset.part;
-        b.classList.toggle('bg-gray-900', active);
-        b.classList.toggle('text-white', active);
-        b.classList.toggle('bg-white', !active);
-        b.classList.toggle('text-gray-900', !active);
-        b.onclick = ()=>{ state.inProgress.part = b.dataset.part; persist(); renderHome(); };
-      });
+      const partWrap = $('#part-buttons');
+      if (partWrap) {
+        const parts = sortJa(state.lists.parts || []);
+        const hasCurrent = parts.includes(state.inProgress.part);
+        if (!hasCurrent && parts.length > 0) {
+          state.inProgress.part = parts[0];
+          persist();
+          afterDataChanged();
+        }
+        partWrap.innerHTML = '';
+        if (parts.length === 0) {
+          const emptyMsg = document.createElement('div');
+          emptyMsg.className = 'text-xs text-gray-500';
+          emptyMsg.textContent = '設定から部位を追加してください。';
+          partWrap.appendChild(emptyMsg);
+        } else {
+          parts.forEach(part => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.dataset.part = part;
+            btn.className = 'part-btn px-3 py-2 rounded-xl border text-sm transition-colors';
+            const active = state.inProgress.part === part;
+            btn.classList.toggle('bg-gray-900', active);
+            btn.classList.toggle('text-white', active);
+            btn.classList.toggle('bg-white', !active);
+            btn.classList.toggle('text-gray-900', !active);
+            btn.textContent = part;
+            btn.onclick = ()=> {
+              state.inProgress.part = part;
+              persist();
+              afterDataChanged();
+              renderHome();
+            };
+            partWrap.appendChild(btn);
+          });
+        }
+      }
 
       const btn = $('#btn-start-or-resume');
       if (btn) {


### PR DESCRIPTION
## Summary
- add a body part selection area on the home screen so users can choose a target muscle group
- render the part list dynamically from the saved configuration and keep the current selection in sync
- notify auto-backup logic when the selected part changes or becomes invalid

## Testing
- npx playwright test *(fails: npm registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68da533a4cf883338b9411b1db57e7cd