### PR TITLE
Fix header title to match Playwright smoke test

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
 <body class="text-gray-900 dark:text-gray-100" data-theme="light">
   <header class="sticky top-0 z-40 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-200 dark:border-gray-700">
     <div class="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
-      <h1 class="text-lg font-bold">筋トレ記録</h1>
+      <h1 class="text-lg font-bold">筋トレメモ</h1>
       <div class="text-xs text-gray-500">Local-only / PWA</div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- update the main header text to "筋トレメモ" so the smoke test sees the expected label

## Testing
- Unable to run Playwright tests locally due to restricted npm registry access

------
https://chatgpt.com/codex/tasks/task_e_68dd003c5d108333a3a0a9b4de3ec6c9