### PR TITLE
Add workout templates and quick start copy option

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BUILD_TAG=SUPERSET-YYYYMMDD</title>
+  <title>BUILD_TAG=TEMPLATE-YYYYMMDD</title>
   <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-Jl0nO9r2yZS3AuNEqFOtPiou0IZ6Tn6PvxI6Bfq5lHppZArYrusS4x+h0/pk3jfb" crossorigin="anonymous"></script>
   <style>
@@ -657,7 +657,7 @@
       });
     };
 
-    const promptText = (title) => {
+    const promptText = (title, initialValue = '') => {
       return openModal(({ finish, cancel }) => {
         const label = createElem('label', { className: 'flex flex-col gap-2' });
         label.append(
@@ -669,10 +669,19 @@
         const ok = createElem('button', { className: 'btn-primary px-4 py-2 rounded-lg text-sm font-semibold', textContent: '決定', attrs: { type: 'button' } });
         cancelBtn.addEventListener('click', cancel);
         const input = label.querySelector('input');
+        if (initialValue) {
+          input.value = initialValue;
+          setTimeout(() => {
+            input.setSelectionRange(0, input.value.length);
+          }, 0);
+        }
         ok.addEventListener('click', () => finish(input.value.trim() || null));
         actions.append(cancelBtn, ok);
         const content = createElem('div', { children: [label, actions] });
-        return { content, focus: () => input.focus() };
+        return { content, focus: () => {
+          input.focus();
+          if (!initialValue) input.select();
+        } };
       });
     };
 
@@ -735,7 +744,8 @@
       historyView: {
         exerciseName: null
       },
-      lastSupersetBlueprint: null
+      lastSupersetBlueprint: null,
+      templates: []
     });
 
     const SUPERSET_SLOT_ROLES = Object.freeze(['A', 'B']);
@@ -846,6 +856,7 @@
     if (!Array.isArray(appData.workouts)) appData.workouts = [];
     normalizeWorkout(appData.currentWorkout);
     appData.workouts.forEach((workout) => normalizeWorkout(workout));
+    if (!Array.isArray(appData.templates)) appData.templates = [];
     createAutoBackupSnapshot();
 
     const persist = () => {
@@ -1387,27 +1398,44 @@
       return true;
     };
 
-    const buildSupersetBlueprint = (workout) => {
-      if (!workout || !Array.isArray(workout.supersets)) return null;
+    const captureWorkoutBlueprint = (workout, { includeSetValues = false } = {}) => {
+      if (!workout || !Array.isArray(workout.supersets)) return [];
       const exerciseMap = new Map((workout.exercises || []).map((exercise) => [exercise.id, exercise]));
       return workout.supersets.map((superset) => ({
-        label: superset.label,
-        restSeconds: superset.restSeconds,
-        slots: superset.slots.map((slot) => {
-          const exercise = slot.exerciseId ? exerciseMap.get(slot.exerciseId) : null;
-          return {
-            role: slot.role,
-            name: exercise ? exercise.name : null,
-            equipment: exercise?.equipment ?? '',
-            attachment: exercise?.attachment ?? '',
-            angle: exercise?.angle ?? null,
-            position: exercise?.position ?? '',
-            intervalSeconds: exercise?.intervalSeconds ?? null,
-            setCount: exercise?.sets?.length ?? 1
-          };
-        })
+        label: superset?.label ?? '',
+        restSeconds: superset?.restSeconds,
+        slots: Array.isArray(superset?.slots)
+          ? superset.slots.map((slot) => {
+              const exercise = slot?.exerciseId ? exerciseMap.get(slot.exerciseId) : null;
+              const base = {
+                role: slot?.role,
+                name: exercise ? exercise.name : null,
+                equipment: exercise?.equipment ?? '',
+                attachment: exercise?.attachment ?? '',
+                angle: exercise?.angle ?? null,
+                position: exercise?.position ?? '',
+                intervalSeconds: exercise?.intervalSeconds ?? null
+              };
+              if (includeSetValues) {
+                base.sets = Array.isArray(exercise?.sets)
+                  ? exercise.sets.map((set) => ({
+                      weight: set?.weight ?? null,
+                      reps: set?.reps ?? null,
+                      note: set?.note ?? ''
+                    }))
+                  : [];
+              } else {
+                base.setCount = exercise?.sets?.length ?? 1;
+              }
+              return base;
+            })
+          : []
       }));
     };
+
+    const buildSupersetBlueprint = (workout) => captureWorkoutBlueprint(workout, { includeSetValues: false });
+
+    const buildWorkoutTemplateBlueprint = (workout) => captureWorkoutBlueprint(workout, { includeSetValues: true });
 
     const restoreSupersetBlueprint = () => {
       const blueprint = appData.lastSupersetBlueprint;
@@ -1432,7 +1460,9 @@
             position: slotConfig.position,
             intervalSeconds: slotConfig.intervalSeconds
           });
-          const desiredCount = Math.max(1, Number(slotConfig.setCount) || 1);
+          const desiredCount = Array.isArray(slotConfig.sets) && slotConfig.sets.length
+            ? slotConfig.sets.length
+            : Math.max(1, Number(slotConfig.setCount) || 1);
           while (exercise.sets.length < desiredCount) {
             exercise.sets.push(createEmptySet());
           }
@@ -1505,6 +1535,202 @@
       const state = getSupersetTimerState(supersetId);
       state.updater = updater;
       updater(state.remaining, state.active);
+    };
+
+    const resetAllSupersetTimers = () => {
+      supersetTimers.forEach((_, key) => stopSupersetTimer(key));
+      supersetTimers.clear();
+    };
+
+    const sanitizeTemplateSets = (sets) => {
+      if (!Array.isArray(sets)) return [];
+      return sets.map((set) => {
+        const base = createEmptySet();
+        const weight = safeNumber(set?.weight);
+        const reps = safeNumber(set?.reps);
+        if (weight !== null) base.weight = weight;
+        if (reps !== null) base.reps = reps;
+        base.note = typeof set?.note === 'string' ? set.note : '';
+        return base;
+      });
+    };
+
+    const createWorkoutFromBlueprint = (blueprint, { startedAt = Date.now() } = {}) => {
+      if (!Array.isArray(blueprint) || !blueprint.length) return null;
+      const workout = {
+        id: `current-${Date.now()}`,
+        startedAt,
+        exercises: [],
+        supersets: []
+      };
+      const today = getTodayDateValue();
+      blueprint.forEach((config, index) => {
+        if (!config) return;
+        const superset = {
+          id: createSupersetId(),
+          label: typeof config.label === 'string' && config.label.trim()
+            ? config.label.trim()
+            : generateSupersetLabel(workout.supersets.length),
+          restSeconds: (() => {
+            const value = safeNumber(config.restSeconds);
+            if (value === null) return DEFAULT_SUPERSET_REST;
+            return Math.max(10, Math.min(600, Math.round(value)));
+          })(),
+          collapsed: false,
+          slots: SUPERSET_SLOT_ROLES.map((role) => ({ role, exerciseId: null }))
+        };
+        const slotMap = new Map(superset.slots.map((slot) => [slot.role, slot]));
+        if (Array.isArray(config.slots)) {
+          config.slots.forEach((slotConfig) => {
+            if (!slotConfig || !slotConfig.role) return;
+            const slot = slotMap.get(slotConfig.role);
+            if (!slot) return;
+            if (!slotConfig.name) return;
+            ensureExerciseCatalog(slotConfig.name);
+            const sanitizedSets = sanitizeTemplateSets(slotConfig.sets);
+            const desiredSets = sanitizedSets.length
+              ? sanitizedSets
+              : Array.from(
+                  { length: Math.max(1, Number(slotConfig.setCount) || 1) },
+                  () => createEmptySet()
+                );
+            const exercise = createExerciseEntity(slotConfig.name, {
+              equipment: slotConfig.equipment,
+              attachment: slotConfig.attachment,
+              angle: slotConfig.angle,
+              position: slotConfig.position,
+              intervalSeconds: slotConfig.intervalSeconds,
+              performedOn: today,
+              sets: desiredSets
+            });
+            workout.exercises.push(exercise);
+            slot.exerciseId = exercise.id;
+            recomputeExercise(workout.id, exercise);
+          });
+        }
+        workout.supersets.push(superset);
+      });
+      workout.supersets = workout.supersets.filter((superset) =>
+        superset.slots.some((slot) => slot.exerciseId)
+      );
+      if (!workout.supersets.length) return null;
+      normalizeWorkout(workout);
+      workout.exercises.forEach((exercise) => recomputeExercise(workout.id, exercise));
+      return workout;
+    };
+
+    const replaceCurrentWorkout = (nextWorkout) => {
+      if (!nextWorkout) return false;
+      resetAllSupersetTimers();
+      appData.currentWorkout = nextWorkout;
+      normalizeWorkout(appData.currentWorkout);
+      appData.currentWorkout.startedAt = nextWorkout.startedAt ?? Date.now();
+      appData.currentWorkout.exercises.forEach((exercise) => recomputeExercise(appData.currentWorkout.id, exercise));
+      appData.lastSupersetBlueprint = buildSupersetBlueprint(appData.currentWorkout);
+      persist();
+      requestRender();
+      clearValidationError();
+      return true;
+    };
+
+    const buildTemplateEntity = (name, blueprint) => ({
+      id: `tpl-${Date.now()}-${Math.random().toString(16).slice(2, 7)}`,
+      name,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      blueprint
+    });
+
+    const getTemplateById = (templateId) => appData.templates.find((tpl) => tpl.id === templateId);
+
+    const applyTemplateById = (templateId) => {
+      const template = getTemplateById(templateId);
+      if (!template || !Array.isArray(template.blueprint)) {
+        showValidationError('テンプレートを読み込めませんでした。');
+        return;
+      }
+      const nextWorkout = createWorkoutFromBlueprint(template.blueprint, { startedAt: Date.now() });
+      if (!nextWorkout) {
+        showValidationError('テンプレートに有効な構成がありません。');
+        return;
+      }
+      if (replaceCurrentWorkout(nextWorkout)) {
+        template.updatedAt = Date.now();
+        persist();
+      }
+    };
+
+    const startWorkoutFromLastHistory = () => {
+      if (!appData.workouts.length) {
+        showValidationError('前回の履歴がありません。');
+        return;
+      }
+      const lastWorkout = cloneDeep(appData.workouts[0]);
+      normalizeWorkout(lastWorkout);
+      const blueprint = buildWorkoutTemplateBlueprint(lastWorkout);
+      const nextWorkout = createWorkoutFromBlueprint(blueprint, { startedAt: Date.now() });
+      if (!nextWorkout) {
+        showValidationError('前回の構成を読み込めませんでした。');
+        return;
+      }
+      replaceCurrentWorkout(nextWorkout);
+    };
+
+    const saveCurrentWorkoutAsTemplate = async () => {
+      if (!appData.currentWorkout.supersets.length) {
+        showValidationError('保存できるスーパーセットがありません。');
+        return;
+      }
+      const name = await promptText('テンプレート名を入力');
+      if (!name) return;
+      const blueprint = buildWorkoutTemplateBlueprint(appData.currentWorkout);
+      if (!Array.isArray(blueprint) || !blueprint.length) {
+        showValidationError('テンプレートに保存できる構成が見つかりませんでした。');
+        return;
+      }
+      const existing = appData.templates.find((tpl) => tpl.name === name);
+      if (existing) {
+        const ok = await confirmAction(`「${name}」を上書きしますか？`);
+        if (!ok) return;
+        existing.blueprint = blueprint;
+        existing.updatedAt = Date.now();
+        persist();
+        requestRender();
+        clearValidationError();
+        return;
+      }
+      const template = buildTemplateEntity(name, blueprint);
+      appData.templates.push(template);
+      persist();
+      requestRender();
+      clearValidationError();
+    };
+
+    const renameTemplate = async (templateId) => {
+      const template = getTemplateById(templateId);
+      if (!template) return;
+      const value = await promptText('テンプレート名を変更', template.name);
+      if (!value) return;
+      if (appData.templates.some((tpl) => tpl.id !== templateId && tpl.name === value)) {
+        showValidationError('同じ名前のテンプレートが既に存在します。');
+        return;
+      }
+      template.name = value;
+      template.updatedAt = Date.now();
+      persist();
+      requestRender();
+      clearValidationError();
+    };
+
+    const deleteTemplate = async (templateId) => {
+      const template = getTemplateById(templateId);
+      if (!template) return;
+      const ok = await confirmAction(`テンプレート「${template.name}」を削除しますか？`);
+      if (!ok) return;
+      appData.templates = appData.templates.filter((tpl) => tpl.id !== templateId);
+      persist();
+      requestRender();
+      clearValidationError();
     };
 
     const supersetFocusRegistry = new Map();
@@ -1704,8 +1930,7 @@
       workoutCopy.exercises.forEach((exercise) => recomputeExercise(workoutCopy.id, exercise));
       appData.workouts.unshift(workoutCopy);
       appData.lastSupersetBlueprint = buildSupersetBlueprint(appData.currentWorkout);
-      supersetTimers.forEach((_, key) => stopSupersetTimer(key));
-      supersetTimers.clear();
+      resetAllSupersetTimers();
       appData.currentWorkout = {
         id: `current-${Date.now()}`,
         startedAt: Date.now(),
@@ -2264,7 +2489,8 @@
         },
         historyView: {
           exerciseName: historyExerciseName
-        }
+        },
+        templates: base.templates
       };
 
       return { issues, data };
@@ -2315,6 +2541,7 @@
         }
         oneRmMemo.clear();
         appData = data;
+        if (!Array.isArray(appData.templates)) appData.templates = [];
         recomputeAll();
         persist();
         requestRender();
@@ -2401,6 +2628,119 @@
 
     const buildHomeView = () => {
       const nodes = [];
+
+      const quickBody = createElem('div', { className: 'space-y-5' });
+      const quickActions = createElem('div', { className: 'flex flex-col gap-3 sm:flex-row' });
+
+      const startLastBtn = createElem('button', {
+        className:
+          'btn-primary flex-1 rounded-xl px-4 py-3 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
+        textContent: '前回コピーで開始',
+        attrs: { type: 'button' }
+      });
+      if (!appData.workouts.length) {
+        startLastBtn.disabled = true;
+        startLastBtn.classList.add('cursor-not-allowed', 'opacity-60');
+        startLastBtn.setAttribute('title', '前回の履歴がありません。');
+      }
+      startLastBtn.addEventListener('click', startWorkoutFromLastHistory);
+
+      const saveTemplateBtn = createElem('button', {
+        className:
+          'btn-muted flex-1 rounded-xl border border-slate-300 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500',
+        textContent: 'テンプレートを保存',
+        attrs: { type: 'button' }
+      });
+      if (!appData.currentWorkout.supersets.length) {
+        saveTemplateBtn.disabled = true;
+        saveTemplateBtn.classList.add('cursor-not-allowed', 'opacity-60');
+        saveTemplateBtn.setAttribute('title', '保存できるスーパーセットがありません。');
+      }
+      saveTemplateBtn.addEventListener('click', saveCurrentWorkoutAsTemplate);
+
+      quickActions.append(startLastBtn, saveTemplateBtn);
+      quickBody.append(quickActions);
+
+      const templateSection = createElem('div', { className: 'space-y-3' });
+      templateSection.append(createElem('h3', { className: 'text-base font-semibold text-slate-800', textContent: 'テンプレート' }));
+
+      if (!appData.templates.length) {
+        templateSection.append(
+          createElem('p', {
+            className: 'text-sm text-slate-700',
+            textContent: '保存されたテンプレートはまだありません。'
+          })
+        );
+      } else {
+        const list = createElem('div', { className: 'space-y-3' });
+        const sortedTemplates = appData.templates
+          .slice()
+          .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+        sortedTemplates.forEach((template) => {
+          const item = createElem('article', { className: 'space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm' });
+          const header = createElem('div', { className: 'flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between' });
+          header.append(createElem('p', { className: 'text-sm font-semibold text-slate-900', textContent: template.name }));
+          const updatedText = template.updatedAt ? `最終更新: ${formatDate(template.updatedAt)}` : '最終更新: -';
+          header.append(createElem('span', { className: 'text-xs text-slate-600', textContent: updatedText }));
+          item.append(header);
+
+          const blueprint = Array.isArray(template.blueprint) ? template.blueprint : [];
+          let exerciseCount = 0;
+          let totalSets = 0;
+          blueprint.forEach((config) => {
+            if (!Array.isArray(config?.slots)) return;
+            config.slots.forEach((slot) => {
+              if (slot?.name) exerciseCount += 1;
+              if (Array.isArray(slot?.sets) && slot.sets.length) {
+                totalSets += slot.sets.length;
+              } else if (Number.isFinite(Number(slot?.setCount))) {
+                totalSets += Math.max(0, Number(slot.setCount));
+              }
+            });
+          });
+          const supersetCount = blueprint.length;
+          item.append(
+            createElem('p', {
+              className: 'text-xs text-slate-600',
+              textContent: `スーパーセット ${supersetCount} / 種目 ${exerciseCount} / 総セット ${totalSets}`
+            })
+          );
+
+          const buttonRow = createElem('div', { className: 'flex flex-wrap gap-2' });
+          const loadBtn = createElem('button', {
+            className: 'btn-primary rounded-lg px-3 py-2 text-xs font-semibold shadow-sm sm:text-sm',
+            textContent: '呼び出す',
+            attrs: { type: 'button' }
+          });
+          loadBtn.addEventListener('click', () => applyTemplateById(template.id));
+          buttonRow.append(loadBtn);
+
+          const renameBtn = createElem('button', {
+            className: 'btn-muted rounded-lg px-3 py-2 text-xs font-semibold sm:text-sm',
+            textContent: '名前を変更',
+            attrs: { type: 'button' }
+          });
+          renameBtn.addEventListener('click', () => renameTemplate(template.id));
+          buttonRow.append(renameBtn);
+
+          const deleteBtn = createElem('button', {
+            className:
+              'text-xs font-semibold text-red-700 underline decoration-dotted hover:text-red-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 sm:text-sm',
+            textContent: '削除',
+            attrs: { type: 'button' }
+          });
+          deleteBtn.addEventListener('click', () => deleteTemplate(template.id));
+          buttonRow.append(deleteBtn);
+
+          item.append(buttonRow);
+          list.append(item);
+        });
+        templateSection.append(list);
+      }
+
+      quickBody.append(templateSection);
+      nodes.push(createCard('クイックスタート', quickBody));
+
       const workout = appData.currentWorkout;
       const cardBody = createElem('div', { className: 'space-y-6' });
       const headerInfo = createElem('p', {


### PR DESCRIPTION
## Summary
- add quick-start card on the home view with a "前回コピーで開始" action
- introduce workout templates including save, rename, overwrite, delete, and load flows
- persist template data alongside existing storage and update the document title to the new build tag

## Testing
- npm run serve

------
https://chatgpt.com/codex/tasks/task_e_68ddb8438e508333b328547435616413