### PR TITLE
Add settings-based preset management panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BUILD_TAG=FIX-20251002-DROPDOWNS</title>
+  <title>BUILD_TAG=FIX-20250214-PRESET-SETTINGS</title>
   <meta name="theme-color" content="#111827">
   <link rel="manifest" id="app-manifest" href="#">
   <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
@@ -43,7 +43,7 @@
   (function(){
     'use strict';
 
-    const BUILD_TAG = 'FIX-20251002-DROPDOWNS';
+    const BUILD_TAG = 'FIX-20250214-PRESET-SETTINGS';
 
     const IS_DEV = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]'].includes(window.location.hostname);
     let initializationWarningCount = 0;
@@ -2785,6 +2785,44 @@
       clearValidationError();
     };
 
+    const getSortedTemplates = () =>
+      appData.templates
+        .slice()
+        .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+
+    const pickTemplateId = async (title) => {
+      if (!appData.templates.length) {
+        showValidationError('保存されたテンプレートはまだありません。');
+        return null;
+      }
+      const sorted = getSortedTemplates();
+      const selection = await pickFromList(title, sorted.map((tpl) => tpl.name));
+      if (!selection) return null;
+      const target = sorted.find((tpl) => tpl.name === selection);
+      return target ? target.id : null;
+    };
+
+    const overwriteTemplateWithCurrentWorkout = async (templateId) => {
+      const template = getTemplateById(templateId);
+      if (!template) return;
+      if (!appData.currentWorkout.supersets.length) {
+        showValidationError('上書きできるスーパーセットがありません。');
+        return;
+      }
+      const blueprint = buildWorkoutTemplateBlueprint(appData.currentWorkout);
+      if (!Array.isArray(blueprint) || !blueprint.length) {
+        showValidationError('テンプレートに保存できる構成が見つかりませんでした。');
+        return;
+      }
+      const ok = await confirmAction(`テンプレート「${template.name}」を上書きしますか？`);
+      if (!ok) return;
+      template.blueprint = blueprint;
+      template.updatedAt = Date.now();
+      persist();
+      requestRender();
+      clearValidationError();
+    };
+
     const supersetFocusRegistry = new Map();
 
     const registerSupersetFocusInput = (supersetId, input) => {
@@ -3987,9 +4025,7 @@
         );
       } else {
         const list = createElem('div', { className: 'space-y-3' });
-        const sortedTemplates = appData.templates
-          .slice()
-          .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+        const sortedTemplates = getSortedTemplates();
         sortedTemplates.forEach((template) => {
           const item = createElem('article', { className: 'space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm' });
           const header = createElem('div', { className: 'flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between' });
@@ -4605,6 +4641,118 @@
       });
       catalogSection.append(list);
       cardBody.append(catalogSection);
+
+      const templateManagerSection = (() => {
+        const section = createElem('div', { className: 'space-y-3' });
+        section.append(createElem('h3', { className: 'text-base font-semibold text-slate-800', textContent: 'プリセット管理' }));
+        section.append(
+          createElem('p', {
+            className: 'text-xs text-slate-600',
+            textContent: 'テンプレートの保存や呼び出しを設定タブから操作できます。'
+          })
+        );
+        section.append(
+          createElem('p', {
+            className: 'rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600',
+            textContent: `保存済みプリセット: ${appData.templates.length}件`
+          })
+        );
+
+        const actions = createElem('div', { className: 'grid gap-2 sm:grid-cols-2' });
+        const createActionButton = (label, handler, { variant = 'primary', disabled = false, tooltip = null } = {}) => {
+          const baseClass =
+            variant === 'primary'
+              ? 'btn-primary rounded-xl px-4 py-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500'
+              : 'btn-muted rounded-xl px-4 py-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500';
+          const button = createElem('button', { className: baseClass, textContent: label, attrs: { type: 'button' } });
+          if (disabled) {
+            button.disabled = true;
+            button.classList.add('cursor-not-allowed', 'opacity-60');
+            if (tooltip) button.setAttribute('title', tooltip);
+          } else {
+            button.addEventListener('click', handler);
+          }
+          return button;
+        };
+
+        const hasTemplates = appData.templates.length > 0;
+        const hasCurrentWorkout = appData.currentWorkout.supersets.length > 0;
+
+        actions.append(
+          createActionButton('プリセットを保存', saveCurrentWorkoutAsTemplate, {
+            variant: 'primary',
+            disabled: !hasCurrentWorkout,
+            tooltip: '保存できるスーパーセットがありません。'
+          }),
+          createActionButton(
+            'プリセットを呼び出す',
+            async () => {
+              const templateId = await pickTemplateId('呼び出すテンプレートを選択');
+              if (!templateId) return;
+              applyTemplateById(templateId);
+            },
+            {
+              variant: 'muted',
+              disabled: !hasTemplates,
+              tooltip: '保存されたテンプレートがありません。'
+            }
+          ),
+          createActionButton(
+            'プリセットを上書き',
+            async () => {
+              const templateId = await pickTemplateId('上書きするテンプレートを選択');
+              if (!templateId) return;
+              await overwriteTemplateWithCurrentWorkout(templateId);
+            },
+            {
+              variant: 'muted',
+              disabled: !hasTemplates || !hasCurrentWorkout,
+              tooltip: !hasTemplates
+                ? '保存されたテンプレートがありません。'
+                : '上書きできるスーパーセットがありません。'
+            }
+          ),
+          createActionButton(
+            'プリセットを削除',
+            async () => {
+              const templateId = await pickTemplateId('削除するテンプレートを選択');
+              if (!templateId) return;
+              await deleteTemplate(templateId);
+            },
+            {
+              variant: 'muted',
+              disabled: !hasTemplates,
+              tooltip: '保存されたテンプレートがありません。'
+            }
+          )
+        );
+        section.append(actions);
+
+        if (!hasTemplates) {
+          section.append(
+            createElem('p', { className: 'text-xs text-slate-600', textContent: '保存済みのプリセットはまだありません。' })
+          );
+        } else {
+          const list = createElem('ul', { className: 'space-y-2' });
+          getSortedTemplates().forEach((template) => {
+            const item = createElem('li', {
+              className: 'rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm'
+            });
+            item.append(
+              createElem('p', { className: 'text-sm font-semibold text-slate-900', textContent: template.name }),
+              createElem('p', {
+                className: 'text-xs text-slate-600',
+                textContent: template.updatedAt ? `最終更新: ${formatDate(template.updatedAt)}` : '最終更新: -'
+              })
+            );
+            list.append(item);
+          });
+          section.append(list);
+        }
+
+        return section;
+      })();
+      cardBody.append(templateManagerSection);
 
       const importExportSection = createElem('div', { className: 'space-y-3' });
       importExportSection.append(createElem('h3', { className: 'text-base font-semibold text-slate-800', textContent: 'バックアップ' }));


### PR DESCRIPTION
## Summary
- add a preset management panel to the settings view with save, load, overwrite, and delete actions
- reuse the existing template storage helpers, including a shared sorter and overwrite flow
- update the build tag to reflect the preset settings release

## Testing
- Manual UI verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68ddfc7c01c88333acdfbf42d2825e99