### PR TITLE
Add extended self-check diagnostics and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BUILD_TAG=FIX-20251002-TDZ-1609</title>
+  <title>BUILD_TAG=FIX-20240523-SELF-CHECK-EXT</title>
   <meta name="theme-color" content="#111827">
   <link rel="manifest" id="app-manifest" href="#">
   <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
@@ -45,7 +45,7 @@
   (function(){
     'use strict';
 
-      const BUILD_TAG = 'FIX-20251002-TDZ-1609';
+      const BUILD_TAG = 'FIX-20240523-SELF-CHECK-EXT';
 
     const IS_DEV = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]'].includes(window.location.hostname);
     let initializationWarningCount = 0;
@@ -1042,6 +1042,19 @@
       const entries = [];
       let overall = STATUS.PASS;
       const snapshot = readAutoBackupSnapshot();
+      const testFlags = (appData?.settings?.selfCheck?.testFlags) || {};
+      const LOCK_PENDING_WARN_MS = 4000;
+      const LOCK_PENDING_FAIL_MS = 15000;
+      const BUFFER_WARN_MS = 5000;
+      const BUFFER_FAIL_MS = 20000;
+
+      const describeAge = (ms) => {
+        if (typeof ms !== 'number' || !Number.isFinite(ms) || ms <= 0) return '1秒未満';
+        if (ms < 1000) return '1秒未満';
+        if (ms < 60000) return `約${Math.round(ms / 1000)}秒`;
+        const minutes = ms / 60000;
+        return `約${minutes.toFixed(minutes >= 10 ? 0 : 1)}分`;
+      };
 
       const updateOverall = (status) => {
         if (status === STATUS.FAIL) {
@@ -1062,6 +1075,92 @@
           ? `初期化順序の警告: ${initializationWarningCount}件`
           : '初期化順序の警告は検出されていません。';
         pushEntry('初期化順序', status, detail);
+      })();
+
+      // 入力ロック監視
+      (() => {
+        const now = Date.now();
+        const segments = [];
+        let status = STATUS.PASS;
+        const pendingDuration = typingState.pendingRender && typeof typingDiagnostics.pendingSince === 'number'
+          ? Math.max(0, now - typingDiagnostics.pendingSince)
+          : 0;
+        segments.push(`ブロック回数: ${typingDiagnostics.blockedRenderCount}`);
+        segments.push(`侵入回数: ${typingDiagnostics.breachCount}`);
+        if (typingDiagnostics.lastBlockedAt) {
+          segments.push(`最終ブロック: ${formatDate(typingDiagnostics.lastBlockedAt)}`);
+        }
+        if (typingDiagnostics.lastBlockedRoute) {
+          segments.push(`最終ブロック画面: ${typingDiagnostics.lastBlockedRoute}`);
+        }
+        if (typingDiagnostics.lastBreachAt) {
+          segments.push(`最終侵入: ${formatDate(typingDiagnostics.lastBreachAt)}`);
+        }
+        if (typingDiagnostics.lastBreachRoute) {
+          segments.push(`最終侵入画面: ${typingDiagnostics.lastBreachRoute}`);
+        }
+        if (typingDiagnostics.breachCount > 0) {
+          status = STATUS.FAIL;
+        }
+        if (typingState.pendingRender) {
+          segments.push(`保留レンダー: ${describeAge(pendingDuration)}継続中`);
+          if (pendingDuration > LOCK_PENDING_FAIL_MS) {
+            status = STATUS.FAIL;
+          } else if (status !== STATUS.FAIL && pendingDuration > LOCK_PENDING_WARN_MS) {
+            status = STATUS.WARN;
+          }
+        } else {
+          segments.push('保留レンダー: なし');
+        }
+        if (status !== STATUS.FAIL && testFlags.forceInputLockWarning) {
+          status = STATUS.WARN;
+          segments.push('テストフラグ: 入力ロック警告を強制しています。');
+        }
+        if (status === STATUS.PASS && typingDiagnostics.blockedRenderCount === 0) {
+          segments.push('再描画試行は検出されていません。');
+        }
+        pushEntry('入力ロック監視', status, segments.join(' / '));
+      })();
+
+      // 未コミットバッファ
+      (() => {
+        const now = Date.now();
+        const pending = Array.from(bufferedMutations.entries()).map(([key, entry]) => {
+          const age = typeof entry?.timestamp === 'number' ? Math.max(0, now - entry.timestamp) : 0;
+          const timerState = bufferTimers.has(key) ? bufferTimers.get(key) : undefined;
+          let stage = 'タイマー未登録';
+          if (timerState === null) stage = '入力編集中';
+          else if (timerState) stage = 'コミット待機';
+          else if (timerState === undefined) stage = 'タイマー未登録';
+          else stage = '即時反映';
+          return { key, age, stage };
+        });
+        let status = STATUS.PASS;
+        let detail = '未コミットのバッファはありません。';
+        if (pending.length > 0) {
+          const failCount = pending.filter((item) => item.age > BUFFER_FAIL_MS).length;
+          const warnCount = pending.filter((item) => item.age > BUFFER_WARN_MS).length;
+          if (failCount > 0) {
+            status = STATUS.FAIL;
+          } else if (warnCount > 0) {
+            status = STATUS.WARN;
+          }
+          const lines = pending.slice(0, 4).map((item) => {
+            const seconds = item.age < 1000 ? '<1秒' : `約${Math.round(item.age / 1000)}秒`;
+            return `${item.key}: ${seconds} (${item.stage})`;
+          });
+          if (pending.length > 4) {
+            lines.push(`他${pending.length - 4}件のバッファがあります。`);
+          }
+          detail = `未コミット数: ${pending.length}\n${lines.join('\n')}`;
+        }
+        if (status !== STATUS.FAIL && testFlags.forceBufferWarning) {
+          status = STATUS.WARN;
+          detail = pending.length
+            ? `${detail}\nテストフラグ: 未コミット警告を強制しています。`
+            : 'テストフラグ: 未コミットバッファ警告を強制しています。';
+        }
+        pushEntry('未コミットバッファ', status, detail);
       })();
 
       // スキーマ整合
@@ -1482,7 +1581,13 @@
         },
         exerciseCatalog: DEFAULT_OPTION_CATALOGS.exercise.map((entry) => entry.key),
         lastSelectedPartKey: null,
-        exercisePartHints: {}
+        exercisePartHints: {},
+        selfCheck: {
+          testFlags: {
+            forceInputLockWarning: false,
+            forceBufferWarning: false
+          }
+        }
       },
       historyView: {
         exerciseKey: null
@@ -1750,6 +1855,17 @@
     }
     if (typeof appData.settings.allowProvisionalValues !== 'boolean') {
       appData.settings.allowProvisionalValues = false;
+    }
+    if (!appData.settings.selfCheck || typeof appData.settings.selfCheck !== 'object') {
+      appData.settings.selfCheck = createInitialData().settings.selfCheck;
+    }
+    if (!appData.settings.selfCheck.testFlags || typeof appData.settings.selfCheck.testFlags !== 'object') {
+      appData.settings.selfCheck.testFlags = { forceInputLockWarning: false, forceBufferWarning: false };
+    } else {
+      appData.settings.selfCheck.testFlags = {
+        forceInputLockWarning: Boolean(appData.settings.selfCheck.testFlags.forceInputLockWarning),
+        forceBufferWarning: Boolean(appData.settings.selfCheck.testFlags.forceBufferWarning)
+      };
     }
     ensureExerciseCatalogIntegrity();
     normalizeExercisePartHints();
@@ -2269,6 +2385,7 @@
         typingState.element = null;
         typingState.route = null;
         typingState.pendingRender = false;
+        typingDiagnostics.pendingSince = null;
         typingState.composing = false;
         return false;
       }
@@ -2936,6 +3053,16 @@
       });
     };
 
+    const typingDiagnostics = {
+      blockedRenderCount: 0,
+      lastBlockedRoute: null,
+      lastBlockedAt: null,
+      breachCount: 0,
+      lastBreachRoute: null,
+      lastBreachAt: null,
+      pendingSince: null
+    };
+
     const typingBindings = new WeakMap();
     const typingState = {
       active: false,
@@ -3021,7 +3148,7 @@
     };
 
     const scheduleBufferedCommit = (key, value, executor) => {
-      bufferedMutations.set(key, { value, executor });
+      bufferedMutations.set(key, { value, executor, timestamp: Date.now() });
       if (bufferTimers.has(key)) {
         const handle = bufferTimers.get(key);
         if (handle) {
@@ -3063,6 +3190,7 @@
         typingState.element = event.target;
         typingState.route = appState.route;
         typingState.pendingRender = false;
+        typingDiagnostics.pendingSince = null;
         typingState.composing = false;
         return;
       }
@@ -3072,6 +3200,7 @@
         typingState.element = null;
         typingState.route = null;
         typingState.pendingRender = false;
+        typingDiagnostics.pendingSince = null;
         typingState.composing = false;
       }
     });
@@ -3084,6 +3213,7 @@
       typingState.element = null;
       typingState.route = null;
       typingState.pendingRender = false;
+      typingDiagnostics.pendingSince = null;
       typingState.composing = false;
       if (shouldRender) {
         queueMicrotask(() => requestRender());
@@ -4948,7 +5078,6 @@
         const section = createElem('div', { className: 'space-y-4' });
         section.append(createElem('h3', { className: 'text-base font-semibold text-slate-800', textContent: '自己診断' }));
 
-        const result = runSelfCheck();
         const bannerClassMap = {
           pass: 'bg-green-50 border-green-200 text-green-900',
           warn: 'bg-yellow-50 border-yellow-200 text-yellow-900',
@@ -4960,33 +5089,111 @@
           fail: 'bg-red-100 text-red-800 border-red-300'
         };
 
+        const actionRow = createElem('div', { className: 'flex flex-wrap items-center gap-3' });
+        const runBtn = createElem('button', {
+          className: 'btn-primary rounded-xl px-4 py-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
+          textContent: '自己診断を実行',
+          attrs: { type: 'button' }
+        });
+        const copyBtn = createElem('button', {
+          className: 'btn-muted rounded-xl px-4 py-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500',
+          textContent: '診断レポートをコピー',
+          attrs: { type: 'button' }
+        });
+        actionRow.append(runBtn, copyBtn);
+        section.append(actionRow);
+
         const banner = createElem('div', {
-          className: `rounded-2xl border px-4 py-3 text-sm font-semibold ${bannerClassMap[result.status] || bannerClassMap.pass}`,
-          textContent: result.summaryMessage
+          className: 'rounded-2xl border px-4 py-3 text-sm font-semibold bg-slate-100 text-slate-800'
         });
         section.append(banner);
 
         const list = createElem('ul', { className: 'space-y-3' });
-        result.entries.forEach((entry) => {
-          const item = createElem('li', { className: 'rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm' });
-          const header = createElem('div', { className: 'flex items-start justify-between gap-3' });
-          header.append(
-            createElem('span', { className: 'text-sm font-semibold text-slate-900', textContent: entry.title }),
-            createElem('span', {
-              className: `inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-bold uppercase tracking-wide ${badgeClassMap[entry.status] || badgeClassMap.pass}`,
-              textContent: result.labels[entry.status] || result.labels.pass
-            })
-          );
-          const detail = createElem('p', { className: 'mt-2 whitespace-pre-wrap text-sm text-slate-700 break-words', textContent: entry.detail });
-          item.append(header, detail);
-          list.append(item);
-        });
         section.append(list);
 
-        const copyBtn = createElem('button', { className: 'btn-muted rounded-xl px-4 py-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500', textContent: '診断レポートをコピー', attrs: { type: 'button' } });
+        const testCard = createElem('div', {
+          className: 'space-y-2 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3'
+        });
+        testCard.append(
+          createElem('p', {
+            className: 'text-[11px] font-semibold uppercase tracking-wide text-slate-500',
+            textContent: 'テスト用トグル'
+          })
+        );
+
+        const latestFlags = appData.settings.selfCheck?.testFlags || {};
+        const makeTestToggle = (labelText, flagKey) => {
+          const label = createElem('label', {
+            className: 'flex items-center gap-3 text-xs font-semibold text-slate-700'
+          });
+          const input = createElem('input', { attrs: { type: 'checkbox' } });
+          input.checked = Boolean(latestFlags[flagKey]);
+          input.addEventListener('change', (event) => {
+            if (!appData.settings.selfCheck || typeof appData.settings.selfCheck !== 'object') {
+              appData.settings.selfCheck = { testFlags: {} };
+            }
+            if (!appData.settings.selfCheck.testFlags || typeof appData.settings.selfCheck.testFlags !== 'object') {
+              appData.settings.selfCheck.testFlags = {};
+            }
+            appData.settings.selfCheck.testFlags[flagKey] = Boolean(event.target.checked);
+            persist();
+            runDiagnostics();
+          });
+          label.append(input, createElem('span', { textContent: labelText }));
+          return label;
+        };
+
+        testCard.append(
+          makeTestToggle('入力ロック警告を強制', 'forceInputLockWarning'),
+          makeTestToggle('未コミット検知を強制', 'forceBufferWarning'),
+          createElem('p', {
+            className: 'text-[11px] text-slate-500',
+            textContent: 'ONにすると意図的に警告を発火させて挙動を確認できます。'
+          })
+        );
+        section.append(testCard);
+
+        let latestResult = null;
+
+        const applyResult = (result) => {
+          latestResult = result;
+          const statusKey = bannerClassMap[result.status] ? result.status : 'pass';
+          banner.className = `rounded-2xl border px-4 py-3 text-sm font-semibold ${bannerClassMap[statusKey] || bannerClassMap.pass}`;
+          banner.textContent = result.summaryMessage;
+          list.innerHTML = '';
+          result.entries.forEach((entry) => {
+            const item = createElem('li', { className: 'rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm' });
+            const header = createElem('div', { className: 'flex items-start justify-between gap-3' });
+            header.append(
+              createElem('span', { className: 'text-sm font-semibold text-slate-900', textContent: entry.title }),
+              createElem('span', {
+                className: `inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-bold uppercase tracking-wide ${badgeClassMap[entry.status] || badgeClassMap.pass}`,
+                textContent: result.labels[entry.status] || result.labels.pass
+              })
+            );
+            const detail = createElem('p', {
+              className: 'mt-2 whitespace-pre-wrap text-sm text-slate-700 break-words',
+              textContent: entry.detail
+            });
+            item.append(header, detail);
+            list.append(item);
+          });
+        };
+
+        const runDiagnostics = () => {
+          const result = runSelfCheck();
+          applyResult(result);
+        };
+
+        runBtn.addEventListener('click', () => {
+          runDiagnostics();
+        });
+
         copyBtn.addEventListener('click', async () => {
+          const report = latestResult?.report;
+          if (!report) return;
           try {
-            await navigator.clipboard.writeText(result.report);
+            await navigator.clipboard.writeText(report);
             const original = copyBtn.textContent;
             copyBtn.textContent = 'コピーしました';
             copyBtn.disabled = true;
@@ -4998,7 +5205,8 @@
             pushError(`クリップボードへのコピーに失敗しました: ${err?.message || err}`);
           }
         });
-        section.append(copyBtn);
+
+        runDiagnostics();
 
         return section;
       })();
@@ -5035,14 +5243,29 @@
         }
       });
       const host = viewHosts[route] || viewHosts[ROUTES.HOME];
-      if (typingState.active && typingState.route === route) {
-        if (applyTypingPatch()) {
+      const typingLockActive = typingState.active && typingState.route === route;
+      if (typingLockActive) {
+        const patched = applyTypingPatch();
+        if (patched) {
+          const nowIso = new Date().toISOString();
           typingState.pendingRender = true;
+          typingDiagnostics.pendingSince = Date.now();
+          typingDiagnostics.blockedRenderCount += 1;
+          typingDiagnostics.lastBlockedRoute = route;
+          typingDiagnostics.lastBlockedAt = nowIso;
           return;
         }
+        if (typingState.active && typingState.route === route) {
+          const nowIso = new Date().toISOString();
+          typingDiagnostics.breachCount += 1;
+          typingDiagnostics.lastBreachRoute = route;
+          typingDiagnostics.lastBreachAt = nowIso;
+        }
         typingState.pendingRender = false;
+        typingDiagnostics.pendingSince = null;
       } else {
         typingState.pendingRender = false;
+        typingDiagnostics.pendingSince = null;
       }
       const builder = viewBuilders[route] || viewBuilders[ROUTES.HOME];
       const result = builder ? builder() : [];


### PR DESCRIPTION
## Summary
- add runSelfCheck diagnostics for input lock guard breaches and lingering buffered mutations, plus accompanying test flags
- track typing guard telemetry and buffer timestamps to support the new diagnostics
- refresh the settings self-check UI with a run button, copy control, test toggles, and update the build tag

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de0746249083338f6199295b6e05f4