### PR TITLE
Fix safe mode boot syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BUILD_TAG=MARKERS-20240607</title>
+  <title>BUILD_TAG=FIX-20251002-SYNTAX-5378</title>
   <meta name="theme-color" content="#111827">
   <link rel="manifest" id="app-manifest" href="#">
   <script>
@@ -5373,7 +5373,6 @@
                 });
                 round.append(slotGrid);
                 roundsContainer.append(round);
-              }
           }
           body.append(roundsContainer);
 


### PR DESCRIPTION
## Summary
- update the build tag to FIX-20251002-SYNTAX-5378 in the HTML head
- remove the stray closing brace before the safe-mode workout body render to resolve the syntax error

## Testing
- node --check /tmp/app_full.js

------
https://chatgpt.com/codex/tasks/task_e_68de618a255c8333b1bc19d9e3cf97f9