### PR TITLE
Add explicit add-exercise button to workout editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -3555,12 +3555,141 @@
         const yyyy = String(now.getFullYear());
         const mm = String(now.getMonth() + 1).padStart(2, '0');
         const dd = String(now.getDate()).padStart(2, '0');
-        const buildTag = `BUILD_TAG=FIX-FAST-INPUT-${yyyy}${mm}${dd}`;
+        const buildTag = `BUILD_TAG=FIX-ADD-EXERCISE-BUTTON-${yyyy}${mm}${dd}`;
         if (typeof document?.title === 'string') {
           document.title = buildTag;
         }
       } catch (_) {}
     })();
+
+    let pendingExerciseFocusId = null;
+
+    const queueExerciseFocus = (exerciseId) => {
+      if (!exerciseId) return;
+      pendingExerciseFocusId = exerciseId;
+    };
+
+    const resolvePendingExerciseFocus = (exerciseId, candidates = []) => {
+      if (!pendingExerciseFocusId || pendingExerciseFocusId !== exerciseId) return;
+      const target = candidates.find((element) => element && typeof element.focus === 'function');
+      if (!target) return;
+      requestAnimationFrame(() => {
+        if (!target.isConnected) return;
+        try {
+          target.focus();
+        } catch (err) {
+          /* focus best effort */
+        }
+      });
+      pendingExerciseFocusId = null;
+    };
+
+    const findRecentSupersetGroupId = () => {
+      for (let index = appData.currentWorkout.supersets.length - 1; index >= 0; index -= 1) {
+        const superset = appData.currentWorkout.supersets[index];
+        if (!superset || !Array.isArray(superset.slots)) continue;
+        const filled = superset.slots.find((slot) => slot?.exerciseId);
+        if (filled && filled.groupId) {
+          return filled.groupId;
+        }
+      }
+      return null;
+    };
+
+    const startAddExerciseFlow = async () => {
+      if (!appData?.currentWorkout) {
+        showValidationError('ワークアウトが開始されていません。');
+        return;
+      }
+      const workout = appData.currentWorkout;
+      const mode = normalizeEntryMode(workout.entryMode);
+      const defaultPartKey =
+        getActivePartKey() || normalizePartKey(appData.settings?.lastSelectedPartKey) || EXERCISE_PARTS[0]?.key || null;
+      const partOptions = EXERCISE_PARTS.map((part) => ({
+        key: part.key,
+        display: part.key === defaultPartKey ? `${part.label}（推奨）` : part.label
+      }));
+      const partSelection = await pickFromList('部位を選択', partOptions.map((option) => option.display));
+      if (!partSelection) return;
+      const partEntry =
+        partOptions.find((option) => option.display === partSelection) || partOptions.find((option) => option.key === defaultPartKey);
+      const partKey = partEntry ? partEntry.key : partOptions[0]?.key || null;
+      if (!partKey) {
+        showValidationError('部位を特定できませんでした。');
+        return;
+      }
+      const exerciseEntries = getExerciseOptionsForPart(partKey);
+      if (!exerciseEntries.length) {
+        showValidationError('選択した部位に対応する種目が見つかりません。');
+        return;
+      }
+      const exerciseOptions = exerciseEntries.map((entry) => ({
+        key: entry.key,
+        display: entry.label
+      }));
+      const exerciseSelection = await pickFromList('種目を選択', exerciseOptions.map((option) => option.display));
+      if (!exerciseSelection) return;
+      const exerciseEntry =
+        exerciseOptions.find((option) => option.display === exerciseSelection) || exerciseOptions[0];
+      if (!exerciseEntry?.key) {
+        showValidationError('種目を特定できませんでした。');
+        return;
+      }
+      let groupId = null;
+      if (mode === WORKOUT_ENTRY_MODES.superset) {
+        const recentGroup = findRecentSupersetGroupId() || SUPERSET_GROUP_IDS[0];
+        const orderedGroups = [...SUPERSET_GROUP_IDS];
+        orderedGroups.sort((a, b) => {
+          if (a === recentGroup) return -1;
+          if (b === recentGroup) return 1;
+          return 0;
+        });
+        const groupOptions = orderedGroups.map((id) => ({
+          key: id,
+          display: `グループ ${id}${id === recentGroup ? '（推奨）' : ''}`
+        }));
+        const groupSelection = await pickFromList('追加するグループを選択', groupOptions.map((option) => option.display));
+        if (!groupSelection) return;
+        const groupEntry =
+          groupOptions.find((option) => option.display === groupSelection) ||
+          groupOptions.find((option) => option.key === recentGroup);
+        groupId = groupEntry ? groupEntry.key : recentGroup;
+      }
+      const supersetIndex = workout.supersets.length;
+      const superset = createSupersetSkeleton({
+        label: generateSupersetLabel(supersetIndex, mode),
+        mode
+      });
+      const targetSlot = superset.slots.find((slot) => slot.groupId === groupId);
+      if (!targetSlot) {
+        showValidationError('追加先のスロットを特定できませんでした。');
+        return;
+      }
+      const exercise = createExerciseEntity(exerciseEntry.key, { partKey, groupId });
+      exercise.groupId = groupId ?? null;
+      targetSlot.exerciseId = exercise.id;
+      workout.exercises.push(exercise);
+      workout.supersets.push(superset);
+      refreshSupersetLabels();
+      const normalizedPart = normalizePartKey(partKey);
+      if (normalizedPart) {
+        workout.selectedPartKey = normalizedPart;
+        appData.settings.lastSelectedPartKey = normalizedPart;
+      }
+      recordExercisePartHint(exerciseEntry.key, partKey);
+      ensureExerciseCatalog(exerciseEntry.key, partKey);
+      recomputeExercise(workout.id, exercise);
+      queueExerciseFocus(exercise.id);
+      persist();
+      requestRender();
+      clearValidationError();
+    };
+
+    const invokeAddExerciseFlow = () => {
+      startAddExerciseFlow().catch((error) => {
+        showError('種目の追加中にエラーが発生しました', error);
+      });
+    };
 
     const isSetFieldEmpty = (value) => value === null || value === undefined || value === '';
 
@@ -5168,6 +5297,29 @@
       nodes.push(createCard('クイックスタート', quickBody));
 
       const workout = appData.currentWorkout;
+      const addExerciseButtonText = '+ 種目を追加';
+      const buildAddExerciseButton = ({ id = null, block = false, variant = 'primary', extraClasses = '' } = {}) => {
+        const focusRing =
+          'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500';
+        const baseClass =
+          variant === 'accent'
+            ? `rounded-xl px-4 py-2 text-sm font-semibold text-white shadow-sm min-h-11 bg-blue-600 transition hover:bg-blue-700 ${focusRing}`
+            : `btn-primary rounded-xl px-4 py-2 text-sm font-semibold shadow-sm min-h-11 ${focusRing}`;
+        const widthClass = block ? `w-full ${baseClass}` : baseClass;
+        const className = extraClasses ? `${widthClass} ${extraClasses}` : widthClass;
+        const button = createElem('button', {
+          className,
+          textContent: addExerciseButtonText,
+          attrs: { type: 'button', 'aria-label': '種目を追加' }
+        });
+        if (id) button.id = id;
+        button.setAttribute('title', '種目を追加');
+        button.addEventListener('click', (event) => {
+          event.preventDefault();
+          invokeAddExerciseFlow();
+        });
+        return button;
+      };
       const cardBody = createElem('div', { className: 'space-y-5' });
       const partSelector = (() => {
         const section = createElem('section', { className: 'space-y-2' });
@@ -5220,6 +5372,11 @@
         );
         return wrapper;
       })();
+      const headerAddButton = buildAddExerciseButton({ extraClasses: 'w-full sm:w-auto' });
+      const headerControls = createElem('div', {
+        className: 'flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3'
+      });
+      headerControls.append(toggleContainer, headerAddButton);
       const headerInfo = createElem('p', {
         className: 'rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-800',
         textContent: `開始: ${formatDate(workout.startedAt)}`
@@ -5243,6 +5400,11 @@
             textContent: emptyMessage
           })
         );
+        const emptyActions = createElem('div', {
+          className: 'flex flex-col gap-2 sm:flex-row sm:items-center'
+        });
+        emptyActions.append(buildAddExerciseButton({ extraClasses: 'w-full sm:w-auto' }));
+        cardBody.append(emptyActions);
       } else {
         workout.supersets.forEach((superset) => {
           supersetFocusRegistry.set(superset.id, []);
@@ -5584,6 +5746,9 @@
                     noteField.classList.add('md:col-span-2');
                     detailBody.append(noteField);
                     noteInputs.push(noteInput);
+                    if (index === 0) {
+                      resolvePendingExerciseFocus(exercise.id, [weightInput, repsInput, noteInput]);
+                    }
 
                     oneRmLabel = createElem('p', {
                       className: 'rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium leading-snug text-slate-800 md:col-span-2',
@@ -5651,7 +5816,7 @@
           cardBody.append(supCard);
         });
       }
-      const addExerciseLabel = workout.entryMode === WORKOUT_ENTRY_MODES.single ? '種目を追加' : 'スーパーセットを追加';
+      const addExerciseTitle = '種目を追加';
       const latestSuperset = workout.supersets[workout.supersets.length - 1] || null;
       const actionBarContainer = createElem('div', { className: 'pointer-events-auto mx-auto max-w-3xl' });
       const actionBar = createElem('div', {
@@ -5663,12 +5828,8 @@
         attrs: { type: 'button', title: '完了して履歴へ' }
       });
       saveBtn.addEventListener('click', finishWorkout);
-      const addBtn = createElem('button', {
-        className: 'btn-muted w-full rounded-xl border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500',
-        textContent: '追加',
-        attrs: { type: 'button', title: addExerciseLabel }
-      });
-      addBtn.addEventListener('click', addSuperset);
+      const addBtn = buildAddExerciseButton({ id: 'btn-add-exercise', block: true, variant: 'accent' });
+      addBtn.setAttribute('title', addExerciseTitle);
       const duplicateBtn = createElem('button', {
         className: 'btn-muted w-full rounded-xl border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500',
         textContent: '複製',
@@ -5686,7 +5847,7 @@
       actionBar.append(saveBtn, addBtn, duplicateBtn);
       actionBarContainer.append(actionBar);
       scheduleActionBar([actionBarContainer]);
-      nodes.push(createCard('現在のワークアウト', cardBody, { headerNodes: [toggleContainer] }));
+      nodes.push(createCard('現在のワークアウト', cardBody, { headerNodes: [headerControls] }));
       return nodes;
     };
 


### PR DESCRIPTION
## Summary
- add an async add-exercise flow that guides part/exercise/group selection and injects a ready-to-edit block
- surface a reusable “+ 種目を追加” button across the workout header, empty state, and fixed action bar
- queue focus for the first set inputs of a newly created exercise to keep data entry fast

## Testing
- npm test *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68df808a81908333ad5b4f92fcc102b4