### PR TITLE
Restore workout view and tighten layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5138,10 +5138,10 @@
     };
 
 <!-- PATCH-START: UI-DENSITY -->
-    const GYM_BUILD_TAG = 'FIX-UI-COMPACT-20250219';
+    const GYM_BUILD_TAG = 'FIX-UI-RECOVERY-20250220';
     const enforceBuildIdentity = () => {
       if (typeof document === 'undefined') return;
-      const desiredTitle = `BUILD_TAG=${GYM_BUILD_TAG}`;
+      const desiredTitle = GYM_BUILD_TAG;
       if (document.title !== desiredTitle) {
         document.title = desiredTitle;
       }
@@ -5213,9 +5213,9 @@
       enhanceInputTarget(control);
     };
     const createExerciseMetaPanel = (exercise) => {
-      const metaPanel = createElem('div', { className: 'space-y-3 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm' });
+      const metaPanel = createElem('div', { className: 'space-y-2 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm' });
 
-      const equipmentRow = createElem('div', { className: 'grid grid-cols-1 gap-2 md:grid-cols-2' });
+      const equipmentRow = createElem('div', { className: 'grid grid-cols-1 gap-1.5 md:grid-cols-2' });
       const equipmentControl = createOptionControl({
         field: 'equipment',
         valueKey: exercise.equipmentKey,
@@ -5235,7 +5235,7 @@
       equipmentRow.append(equipmentField, attachmentField);
       metaPanel.append(equipmentRow);
 
-      const angleRow = createElem('div', { className: 'grid grid-cols-1 gap-2 md:grid-cols-2' });
+      const angleRow = createElem('div', { className: 'grid grid-cols-1 gap-1.5 md:grid-cols-2' });
       const angleInput = createElem('input', {
         className: 'input-base text-slate-900 placeholder-slate-500',
         attrs: { type: 'number', inputmode: 'decimal', min: '0', max: '180', step: '1', placeholder: '例: 30' },
@@ -5265,7 +5265,7 @@
       angleRow.append(angleField, positionField);
       metaPanel.append(angleRow);
 
-      const scheduleRow = createElem('div', { className: 'grid grid-cols-1 gap-2 md:grid-cols-2' });
+      const scheduleRow = createElem('div', { className: 'grid grid-cols-1 gap-1.5 md:grid-cols-2' });
       const performedOnInput = createElem('input', {
         className: 'input-base text-slate-900',
         attrs: { type: 'date', min: '2000-01-01', max: '2099-12-31', step: '1' },
@@ -5316,7 +5316,7 @@
       });
     };
 
-    const applyCompactCardBase = (card, { padding = 'p-4', margin = 'mb-4' } = {}) => {
+    const applyCompactCardBase = (card, { padding = 'p-3', margin = 'mb-3' } = {}) => {
       if (!card) return;
       const paddingCandidates = ['p-5', 'p-4'];
       paddingCandidates.forEach((candidate) => {
@@ -5364,7 +5364,7 @@
     const applyQuickStartCompact = (card) => {
       if (!card || card.dataset.quickCompact === '1') return;
       card.dataset.quickCompact = '1';
-      applyCompactCardBase(card, { padding: 'p-3', margin: 'mb-3' });
+      applyCompactCardBase(card, { padding: 'p-3', margin: 'mb-2.5' });
       const header = card.querySelector(':scope > header');
       if (header) {
         ensureCompactSpacing(header.classList, ['mb-4', 'gap-3'], ['mb-2', 'gap-2', 'flex-wrap']);
@@ -5374,9 +5374,8 @@
         ensureCompactSpacing(body.classList, ['space-y-5', 'space-y-4', 'space-y-3'], ['space-y-2']);
         const primaryRow = body.firstElementChild;
         if (primaryRow) {
-          primaryRow.classList.remove('flex-col');
-          ensureCompactSpacing(primaryRow.classList, ['gap-3'], ['gap-2']);
-          primaryRow.classList.add('flex', 'flex-wrap');
+          primaryRow.classList.remove('flex-col', 'gap-3', 'gap-4');
+          primaryRow.classList.add('flex', 'flex-wrap', 'gap-2');
         }
         if (primaryRow?.classList.contains('sm:flex-row')) {
           primaryRow.classList.add('sm:flex-row');
@@ -5385,8 +5384,14 @@
           if (btn.classList.contains('py-3')) {
             btn.classList.replace('py-3', 'py-2');
           }
+          if (btn.classList.contains('py-2.5')) {
+            btn.classList.replace('py-2.5', 'py-2');
+          }
           if (btn.classList.contains('px-4')) {
             btn.classList.replace('px-4', 'px-3');
+          }
+          if (btn.classList.contains('px-5')) {
+            btn.classList.replace('px-5', 'px-3');
           }
           if (!btn.classList.contains('min-h-[44px]')) {
             btn.classList.add('min-h-[44px]');
@@ -5436,7 +5441,13 @@
       }
       card.querySelectorAll('button').forEach((btn) => {
         if (btn.classList.contains('py-3')) {
-          btn.classList.replace('py-3', 'py-2.5');
+          btn.classList.replace('py-3', 'py-2');
+        }
+        if (btn.classList.contains('py-2.5')) {
+          btn.classList.replace('py-2.5', 'py-2');
+        }
+        if (btn.classList.contains('px-4')) {
+          btn.classList.replace('px-4', 'px-3');
         }
         if (!btn.classList.contains('min-h-[44px]')) {
           btn.classList.add('min-h-[44px]');
@@ -5447,7 +5458,7 @@
     const applyCurrentWorkoutCompact = (card) => {
       if (!card || card.dataset.workoutCompact === '1') return;
       card.dataset.workoutCompact = '1';
-      applyCompactCardBase(card, { padding: 'p-4', margin: 'mb-3' });
+      applyCompactCardBase(card, { padding: 'p-3', margin: 'mb-3' });
       const header = card.querySelector(':scope > header');
       if (header) {
         ensureCompactSpacing(header.classList, ['mb-4', 'gap-3'], ['mb-2', 'gap-2', 'flex-wrap']);
@@ -5461,15 +5472,13 @@
       }
       const body = card.querySelector(':scope > div');
       if (body) {
-        ensureCompactSpacing(body.classList, ['space-y-5', 'space-y-4'], ['space-y-3']);
+        ensureCompactSpacing(body.classList, ['space-y-6', 'space-y-5', 'space-y-4'], ['space-y-3']);
         if (body.classList.contains('pb-24')) {
           body.classList.replace('pb-24', 'pb-20');
         }
         const metaGrid = body.querySelector('div.grid');
         if (metaGrid) {
-          metaGrid.classList.remove('grid-cols-1');
-          metaGrid.classList.remove('md:grid-cols-2');
-          metaGrid.classList.add('grid-cols-2', 'gap-2');
+          ensureCompactSpacing(metaGrid.classList, ['gap-4', 'gap-3', 'gap-2'], ['gap-1.5']);
         }
         const partSelect = body.querySelector('select[name="part-selector"]');
         if (partSelect) {
@@ -6468,7 +6477,34 @@
     };
 
 <!-- PATCH-START: WORKOUT-RENDER -->
+    const renderWorkout = (appFlags = {}) => {
+      const homeNodes = buildHomeView(appFlags);
+      const nodes = Array.isArray(homeNodes)
+        ? homeNodes.slice()
+        : homeNodes
+          ? [homeNodes]
+          : [];
+      const workoutCard = nodes.find((node) => {
+        if (!node || typeof node.querySelector !== 'function') return false;
+        const title = node.querySelector(':scope > header h2');
+        return title?.textContent?.trim() === '現在のワークアウト';
+      });
+      if (workoutCard) {
+        nodes.forEach((node) => {
+          if (node !== workoutCard && typeof node.remove === 'function' && !node.isConnected) {
+            node.remove();
+          }
+        });
+        return [workoutCard];
+      }
+      return nodes;
+    };
+
     const buildWorkoutView = (appFlags = {}) => {
+      const renderNodes = renderWorkout(appFlags);
+      if (Array.isArray(renderNodes) && renderNodes.length) {
+        return renderNodes;
+      }
       const nodes = [];
       const cardBody = createElem('div', { className: 'space-y-6' });
       if (!appData.workouts.length) {


### PR DESCRIPTION
## Summary
- ensure the workout route reuses the full current-workout card by restoring a renderWorkout helper
- reduce padding, gaps, and message sizing across quick start and workout cards for a slimmer layout
- pin the UI build tag to FIX-UI-RECOVERY-20250220 so the document title and data attributes stay aligned

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dfa72310cc8333b5dc5f075de5c851