### PR TITLE
Add render fallbacks to prevent blank UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -5153,20 +5153,49 @@
       document.body?.setAttribute('data-build-tag', GYM_BUILD_TAG);
     };
     enforceBuildIdentity();
+    const ensureVisibilityFallback = () => {
+      if (typeof document === 'undefined') return;
+      try {
+        document.documentElement.style.background = '#ffffff';
+        document.documentElement.style.colorScheme = 'light';
+        const bodyEl = document.body;
+        if (bodyEl) {
+          bodyEl.style.background = '#ffffff';
+          bodyEl.style.color = '#0f172a';
+        }
+        const appEl = document.getElementById('app');
+        if (appEl) {
+          appEl.style.minHeight = '60vh';
+          appEl.style.display = 'block';
+          appEl.style.visibility = 'visible';
+          appEl.style.opacity = '1';
+        }
+      } catch (_) {}
+    };
+    ensureVisibilityFallback();
     if (typeof document !== 'undefined' && typeof MutationObserver === 'function') {
       const titleEl = document.querySelector('title');
       if (titleEl) {
-        const titleObserver = new MutationObserver(enforceBuildIdentity);
+        const titleObserver = new MutationObserver(() => {
+          enforceBuildIdentity();
+          ensureVisibilityFallback();
+        });
         titleObserver.observe(titleEl, { childList: true, subtree: true, characterData: true });
       }
       const htmlEl = document.documentElement;
       if (htmlEl) {
-        const attrObserver = new MutationObserver(enforceBuildIdentity);
+        const attrObserver = new MutationObserver(() => {
+          enforceBuildIdentity();
+          ensureVisibilityFallback();
+        });
         attrObserver.observe(htmlEl, { attributes: true, attributeFilter: ['data-build-tag'] });
       }
       const bodyEl = document.body;
       if (bodyEl) {
-        const bodyObserver = new MutationObserver(enforceBuildIdentity);
+        const bodyObserver = new MutationObserver(() => {
+          enforceBuildIdentity();
+          ensureVisibilityFallback();
+        });
         bodyObserver.observe(bodyEl, { attributes: true, attributeFilter: ['data-build-tag'] });
       }
     }
@@ -7076,7 +7105,12 @@
       optionControlSequence = 0;
       scheduledActionBarContent = null;
       if (!appRoot) return;
-      const route = ROUTE_VALUES.has(state.route) ? state.route : ROUTES.HOME;
+      // ルート不整合時はHOMEへ強制
+      let route = ROUTE_VALUES.has(state.route) ? state.route : ROUTES.HOME;
+      if (!ROUTE_VALUES.has(route)) {
+        route = ROUTES.HOME;
+        state = { ...state, route };
+      }
       syncSafeBanner(Boolean(lastRenderFlags.safeMode));
       updateTabState(route);
       Object.entries(viewHosts).forEach(([key, host]) => {
@@ -7113,8 +7147,32 @@
       }
       const builder = viewBuilders[route] || viewBuilders[ROUTES.HOME];
       const result = builder ? builder(lastRenderFlags) : [];
-      const nodes = Array.isArray(result) ? result : (result ? [result] : []);
-      host.replaceChildren(...nodes);
+      // Node以外が混じっても安全に捨てる
+      const nodes = Array.isArray(result)
+        ? result.filter((n) => n instanceof Node)
+        : (result instanceof Node ? [result] : []);
+      if (nodes.length === 0) {
+        // 第1フォールバック：最小カードを差し込む
+        const fb = document.createElement('section');
+        fb.className = 'rounded-2xl border border-slate-200 bg-white p-4 shadow-sm';
+        fb.innerHTML =
+          '<h2 class="text-base font-bold text-slate-900">表示できるコンテンツがありません</h2>' +
+          '<p class="text-sm text-slate-700 mt-1">ホームに戻ってやり直すか、再読込してください。</p>';
+        host.replaceChildren(fb);
+      } else {
+        host.replaceChildren(...nodes);
+      }
+      ensureVisibilityFallback?.();
+      // 第2フォールバック：#app が空なら強制的に可視ノードを追加
+      try {
+        const rootEl = appRoot || document.getElementById('app');
+        if (rootEl && !rootEl.childElementCount) {
+          const msg = document.createElement('div');
+          msg.className = 'rounded-2xl border border-slate-200 bg-white p-4 shadow-sm';
+          msg.innerHTML = '<p class="text-sm text-slate-700">レンダリング保護により代替表示中です。</p>';
+          rootEl.appendChild(msg);
+        }
+      } catch (_) {}
       applyScheduledActionBar(route);
     };
 


### PR DESCRIPTION
## Summary
- ensure invalid routes fall back to the home view and always mount at least one visible node
- add rendering safeguards that filter out non-node responses and inject emergency fallback content when needed
- enforce document and app container visibility styles with observers so the UI never renders blank

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0637cf09083338afa4676a0854963